### PR TITLE
chore: add publish workflow and update README files for colibri and core

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: Publish
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: 2.2.2
+      - name: Publish package
+        run: deno publish

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# colibri
+# @colibri
 
 WIP(🪶)

--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,3 @@
+# @colibri/core
+
+Core Tools WIP(🪶)

--- a/core/deno.json
+++ b/core/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@colibri/core",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha",
+  "license": "MIT",
   "exports": {
     ".": "./mod.ts"
   },


### PR DESCRIPTION
This pull request sets up publishing automation for the project and introduces some initial documentation and configuration updates for the core package. The most important changes are the addition of a GitHub Actions workflow for publishing, updates to the package naming and versioning, and initial documentation for both the main and core packages.

**Automation and CI/CD:**
* Added a new GitHub Actions workflow in `.github/workflows/publish.yml` to automate publishing the package on pushes to the `main` branch using Deno.

**Documentation:**
* Updated the main `README.md` to use the scoped package name `@colibri` and clarified its WIP status.
* Added a new `README.md` in the `core` directory documenting the core tools and their WIP status under the name `@colibri/core`.

**Package Configuration:**
* Updated `core/deno.json` to set the package name to `@colibri/core`, change the version to `0.1.0-alpha`, and add an MIT license field.