### PR TITLE
fix(publish): update include paths in deno.json for consistency

### DIFF
--- a/core/deno.json
+++ b/core/deno.json
@@ -9,6 +9,6 @@
     "plugins": ["../_tools/lint/enum-requires-own-file.ts"]
   },
   "publish": {
-    "include": ["mod.ts", "src/**/*.ts", "README.md", "LICENSE"]
+    "include": ["mod.ts", "./**/*.ts", "README.md", "LICENSE"]
   }
 }


### PR DESCRIPTION
This pull request makes a small update to the `core/deno.json` configuration file. The change broadens the file inclusion pattern for publishing, ensuring that all TypeScript files in any subdirectory are included.