### PR TITLE
fix(types): add generic types to ProcessEngine.create for transaction…

### DIFF
--- a/core/processes/assemble-transaction/index.ts
+++ b/core/processes/assemble-transaction/index.ts
@@ -39,9 +39,10 @@ const assembleTransactionProcess = async (
   }
 };
 
-export const AssembleTransaction = ProcessEngine.create(
-  assembleTransactionProcess,
-  {
-    name: "AssembleTransaction",
-  }
-);
+export const AssembleTransaction = ProcessEngine.create<
+  AssembleTransactionInput,
+  AssembleTransactionOutput,
+  E.AssembleTransactionError
+>(assembleTransactionProcess, {
+  name: "AssembleTransaction",
+});

--- a/core/processes/build-transaction/index.ts
+++ b/core/processes/build-transaction/index.ts
@@ -166,6 +166,10 @@ const appendPreconditions = (
   return tx;
 };
 
-export const BuildTransaction = ProcessEngine.create(buildTransactionProcess, {
+export const BuildTransaction = ProcessEngine.create<
+  BuildTransactionInput,
+  BuildTransactionOutput,
+  E.BuildTransactionError
+>(buildTransactionProcess, {
   name: "BuildTransaction",
 });

--- a/core/processes/simulate-transaction/index.ts
+++ b/core/processes/simulate-transaction/index.ts
@@ -49,9 +49,10 @@ const simulateTransactionProcess = async (
   }
 };
 
-export const SimulateTransaction = ProcessEngine.create(
-  simulateTransactionProcess,
-  {
-    name: "SimulateTransaction",
-  }
-);
+export const SimulateTransaction = ProcessEngine.create<
+  SimulateTransactionInput,
+  SimulateTransactionOutput,
+  E.SimulateTransactionError
+>(simulateTransactionProcess, {
+  name: "SimulateTransaction",
+});


### PR DESCRIPTION
This pull request updates the creation of three transaction-related processes to use explicit generic type parameters with the `ProcessEngine.create` function. This change improves type safety and clarity in the codebase by specifying input, output, and error types for each process.

**Type safety and process definition improvements:**

* Updated `AssembleTransaction` in `core/processes/assemble-transaction/index.ts` to use generic types: `AssembleTransactionInput`, `AssembleTransactionOutput`, and `E.AssembleTransactionError`.
* Updated `BuildTransaction` in `core/processes/build-transaction/index.ts` to use generic types: `BuildTransactionInput`, `BuildTransactionOutput`, and `E.BuildTransactionError`.
* Updated `SimulateTransaction` in `core/processes/simulate-transaction/index.ts` to use generic types: `SimulateTransactionInput`, `SimulateTransactionOutput`, and `E.SimulateTransactionError`.… processes