### PR TITLE
Refactor: Separate exports for inference

### DIFF
--- a/core/processes/assemble-transaction/index.ts
+++ b/core/processes/assemble-transaction/index.ts
@@ -39,9 +39,10 @@ const assembleTransactionProcess = async (
   }
 };
 
-export const AssembleTransaction = ProcessEngine.create(
-  assembleTransactionProcess,
-  {
-    name: "AssembleTransaction",
-  }
-);
+export const AssembleTransaction = ProcessEngine.create<
+  AssembleTransactionInput,
+  AssembleTransactionOutput,
+  E.AssembleTransactionError
+>(assembleTransactionProcess, {
+  name: "AssembleTransaction",
+});

--- a/core/processes/assemble-transaction/index.ts
+++ b/core/processes/assemble-transaction/index.ts
@@ -39,10 +39,12 @@ const assembleTransactionProcess = async (
   }
 };
 
-export const AssembleTransaction = ProcessEngine.create<
+const AssembleTransaction = ProcessEngine.create<
   AssembleTransactionInput,
   AssembleTransactionOutput,
   E.AssembleTransactionError
 >(assembleTransactionProcess, {
   name: "AssembleTransaction",
 });
+
+export { AssembleTransaction };

--- a/core/processes/build-transaction/index.ts
+++ b/core/processes/build-transaction/index.ts
@@ -166,10 +166,12 @@ const appendPreconditions = (
   return tx;
 };
 
-export const BuildTransaction = ProcessEngine.create<
+const BuildTransaction = ProcessEngine.create<
   BuildTransactionInput,
   BuildTransactionOutput,
   E.BuildTransactionError
 >(buildTransactionProcess, {
   name: "BuildTransaction",
 });
+
+export { BuildTransaction };

--- a/core/processes/build-transaction/index.ts
+++ b/core/processes/build-transaction/index.ts
@@ -166,6 +166,10 @@ const appendPreconditions = (
   return tx;
 };
 
-export const BuildTransaction = ProcessEngine.create(buildTransactionProcess, {
+export const BuildTransaction = ProcessEngine.create<
+  BuildTransactionInput,
+  BuildTransactionOutput,
+  E.BuildTransactionError
+>(buildTransactionProcess, {
   name: "BuildTransaction",
 });

--- a/core/processes/simulate-transaction/index.ts
+++ b/core/processes/simulate-transaction/index.ts
@@ -49,10 +49,12 @@ const simulateTransactionProcess = async (
   }
 };
 
-export const SimulateTransaction = ProcessEngine.create<
+const SimulateTransaction = ProcessEngine.create<
   SimulateTransactionInput,
   SimulateTransactionOutput,
   E.SimulateTransactionError
 >(simulateTransactionProcess, {
   name: "SimulateTransaction",
 });
+
+export { SimulateTransaction };

--- a/core/processes/simulate-transaction/index.ts
+++ b/core/processes/simulate-transaction/index.ts
@@ -49,9 +49,10 @@ const simulateTransactionProcess = async (
   }
 };
 
-export const SimulateTransaction = ProcessEngine.create(
-  simulateTransactionProcess,
-  {
-    name: "SimulateTransaction",
-  }
-);
+export const SimulateTransaction = ProcessEngine.create<
+  SimulateTransactionInput,
+  SimulateTransactionOutput,
+  E.SimulateTransactionError
+>(simulateTransactionProcess, {
+  name: "SimulateTransaction",
+});


### PR DESCRIPTION
This pull request updates the way process engine instances are created and exported for transaction-related processes. The main improvement is adding explicit type parameters to the `ProcessEngine.create` calls for better type safety and consistency, and switching from direct export to named export.

**Type safety and process engine creation:**

* Updated `AssembleTransaction`, `BuildTransaction`, and `SimulateTransaction` to use explicit generic type parameters for input, output, and error types in their respective `ProcessEngine.create` calls (`core/processes/assemble-transaction/index.ts`, `core/processes/build-transaction/index.ts`, `core/processes/simulate-transaction/index.ts`). [[1]](diffhunk://#diff-937af59f86ee9d3687ceeb738234a68490953c56daa8e6832caa7155e7ac998dL42-R50) [[2]](diffhunk://#diff-0b36f448974f81c007131aa9a1bcfb5eb0c686985d3db3d583ba91de0935bb55L169-R177) [[3]](diffhunk://#diff-105da855d31fd9ec11393bedddc9f4003b3d254243bc7c088e5f7b943b6826fdL52-R60)

**Export style consistency:**

* Changed exports from direct to named exports for all three process engine instances to improve consistency and maintainability (`core/processes/assemble-transaction/index.ts`, `core/processes/build-transaction/index.ts`, `core/processes/simulate-transaction/index.ts`). [[1]](diffhunk://#diff-937af59f86ee9d3687ceeb738234a68490953c56daa8e6832caa7155e7ac998dL42-R50) [[2]](diffhunk://#diff-0b36f448974f81c007131aa9a1bcfb5eb0c686985d3db3d583ba91de0935bb55L169-R177) [[3]](diffhunk://#diff-105da855d31fd9ec11393bedddc9f4003b3d254243bc7c088e5f7b943b6826fdL52-R60)