### PR TITLE
fix: create channel accounts with zero balance

### DIFF
--- a/core/event/event.unit.test.ts
+++ b/core/event/event.unit.test.ts
@@ -172,6 +172,30 @@ describe("Event", () => {
       assertEquals(event.topics, ["normalized"]);
       assertEquals(event.value, 7);
     });
+
+    it("normalizes xdr-like topic inputs when they return raw bytes", () => {
+      const normalizedTopic = xdr.ScVal.scvSymbol("bytes-normalized");
+      const normalizedValue = xdr.ScVal.scvU32(9);
+      const event = new Event({
+        id: "0000000000000000000-0000000000",
+        type: EventType.Contract,
+        ledger: 12345,
+        ledgerClosedAt: "2024-01-01T00:00:00Z",
+        transactionIndex: 0,
+        operationIndex: 0,
+        inSuccessfulContractCall: true,
+        txHash: "abc123",
+        topic: [{
+          toXDR: () => normalizedTopic.toXDR(),
+        }],
+        value: {
+          toXDR: () => normalizedValue.toXDR(),
+        },
+      });
+
+      assertEquals(event.topics, ["bytes-normalized"]);
+      assertEquals(event.value, 9);
+    });
   });
 
   describe("value getter", () => {

--- a/plugins/channel-accounts/README.md
+++ b/plugins/channel-accounts/README.md
@@ -13,14 +13,15 @@ Colibri classic and Soroban transaction pipelines.
 
 ## Quick start
 
-Create channels, register them in the plugin, and attach the plugin to the
-pipeline you want to accelerate.
+Create channels, register them in the plugin, and pair them with a fee-bump
+plugin if you want zero-balance channels to submit transactions immediately.
 
 ```ts
 import {
   ChannelAccounts,
   createChannelAccountsPlugin,
 } from "@colibri/plugin-channel-accounts";
+import { createFeeBumpPlugin } from "@colibri/plugin-fee-bump";
 import { createClassicTransactionPipeline, NetworkConfig } from "@colibri/core";
 
 const networkConfig = NetworkConfig.TestNet();
@@ -31,15 +32,23 @@ const channels = await ChannelAccounts.open({
   config,
 });
 
-const plugin = createChannelAccountsPlugin({ channels });
+const channelAccountsPlugin = createChannelAccountsPlugin({ channels });
+const feeBumpPlugin = createFeeBumpPlugin({
+  networkConfig,
+  feeBumpConfig: {
+    source: sponsor.address(),
+    fee: "10000000",
+    signers: [sponsor.signer()],
+  },
+});
 const pipeline = createClassicTransactionPipeline({ networkConfig });
-pipeline.use(plugin);
+pipeline.use(channelAccountsPlugin);
+pipeline.use(feeBumpPlugin);
 ```
 
 ## Opening channels
 
-`ChannelAccounts.open(...)` creates and funds a bounded set of sponsored channel
-accounts.
+`ChannelAccounts.open(...)` creates a bounded set of sponsored channel accounts.
 
 - `numberOfChannels` — number of channels to open
 - `sponsor` — account funding and sponsoring the channels
@@ -119,10 +128,12 @@ sac.contract.invokePipe.use(plugin);
 
 ## Notes
 
-- Channels are opened with a starting balance so they can act as transaction
-  sources without requiring a separate fee-bump layer.
-- Channel closing uses a direct channel-sourced `accountMerge`, which works even
-  when the sponsor was added as a signer during channel creation.
+- Channels are opened with `0` balance.
+- If you want zero-balance channels to submit transactions immediately, either
+  fund them separately or combine the pipeline with
+  `@colibri/plugin-fee-bump`.
+- Channel closing keeps the channel as the `accountMerge` operation source while
+  letting the caller-provided transaction config pay the network fee.
 - Adding the sponsor as a channel signer affects the on-chain account shape, but
   it does not yet make sponsor-only signing automatic through current Colibri
   pipeline signing requirements.

--- a/plugins/channel-accounts/deno.json
+++ b/plugins/channel-accounts/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@colibri/plugin-channel-accounts",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "exports": "./mod.ts",
   "license": "MIT",
   "publish": {

--- a/plugins/channel-accounts/src/plugin/classic-transaction.integration.test.ts
+++ b/plugins/channel-accounts/src/plugin/classic-transaction.integration.test.ts
@@ -12,12 +12,14 @@ import {
 } from "@colibri/core";
 import { StellarTestLedger } from "@colibri/test-tooling";
 import {
+  FeeBumpTransaction,
   Operation,
   type Transaction,
   TransactionBuilder,
   type xdr,
 } from "stellar-sdk";
 import { Server } from "stellar-sdk/rpc";
+import { createFeeBumpPlugin } from "../../../fee-bump/mod.ts";
 import {
   type ChannelAccount,
   ChannelAccounts,
@@ -32,11 +34,18 @@ const asEnvelopeXdr = (
 const parseSubmittedTransaction = (
   envelopeXdr: string | xdr.TransactionEnvelope,
   networkPassphrase: string,
-): Transaction =>
+): Transaction | FeeBumpTransaction =>
   TransactionBuilder.fromXDR(
     asEnvelopeXdr(envelopeXdr),
     networkPassphrase,
-  ) as Transaction;
+  ) as Transaction | FeeBumpTransaction;
+
+const getInnerTransaction = (
+  transaction: Transaction | FeeBumpTransaction,
+): Transaction =>
+  transaction instanceof FeeBumpTransaction
+    ? transaction.innerTransaction
+    : transaction;
 
 const sortAddresses = (addresses: readonly string[]) => [...addresses].sort();
 
@@ -131,12 +140,21 @@ describe(
         const plugin = createChannelAccountsPlugin({
           channels,
         });
+        const feeBumpPlugin = createFeeBumpPlugin({
+          networkConfig,
+          feeBumpConfig: {
+            source: sponsor.address(),
+            fee: "20000000",
+            signers: [sponsor.signer()],
+          },
+        });
 
         const pipeline = createClassicTransactionPipeline({
           networkConfig,
           rpc,
         });
         pipeline.use(plugin);
+        pipeline.use(feeBumpPlugin);
 
         const result = await pipeline.run({
           operations: [
@@ -156,9 +174,10 @@ describe(
           result.response.envelopeXdr,
           networkConfig.networkPassphrase,
         );
+        const innerTransaction = getInnerTransaction(transaction);
 
-        assertEquals(transaction.source, channel.address());
-        assertEquals(transaction.operations[0].source, actor.address());
+        assertEquals(innerTransaction.source, channel.address());
+        assertEquals(innerTransaction.operations[0].source, actor.address());
         assertEquals(
           plugin.getChannels().map((item) => item.address()),
           [channel.address()],
@@ -181,12 +200,21 @@ describe(
         const plugin = createChannelAccountsPlugin({
           channels,
         });
+        const feeBumpPlugin = createFeeBumpPlugin({
+          networkConfig,
+          feeBumpConfig: {
+            source: sponsor.address(),
+            fee: "20000000",
+            signers: [sponsor.signer()],
+          },
+        });
 
         const pipeline = createClassicTransactionPipeline({
           networkConfig,
           rpc,
         });
         pipeline.use(plugin);
+        pipeline.use(feeBumpPlugin);
 
         const parallelResults = await Promise.all(
           Array.from({ length: 10 }, (_, index) =>
@@ -213,7 +241,7 @@ describe(
             networkConfig.networkPassphrase,
           );
 
-          return transaction.source;
+          return getInnerTransaction(transaction).source;
         });
 
         assertEquals(
@@ -240,11 +268,12 @@ describe(
           followUpResult.response.envelopeXdr,
           networkConfig.networkPassphrase,
         );
+        const followUpInnerTransaction = getInnerTransaction(followUpTransaction);
 
         assertEquals(
           channels
             .map((channel) => String(channel.address()))
-            .includes(String(followUpTransaction.source)),
+            .includes(String(followUpInnerTransaction.source)),
           true,
         );
         assertEquals(

--- a/plugins/channel-accounts/src/plugin/invoke-contract.testnet.integration.test.ts
+++ b/plugins/channel-accounts/src/plugin/invoke-contract.testnet.integration.test.ts
@@ -11,11 +11,13 @@ import {
 } from "@colibri/core";
 import {
   Asset,
+  FeeBumpTransaction,
   Operation,
   type Transaction,
   TransactionBuilder,
   type xdr,
 } from "stellar-sdk";
+import { createFeeBumpPlugin } from "../../../fee-bump/mod.ts";
 import { ChannelAccounts, createChannelAccountsPlugin } from "@/index.ts";
 
 const asEnvelopeXdr = (
@@ -26,11 +28,18 @@ const asEnvelopeXdr = (
 const parseSubmittedTransaction = (
   envelopeXdr: string | xdr.TransactionEnvelope,
   networkPassphrase: string,
-): Transaction =>
+): Transaction | FeeBumpTransaction =>
   TransactionBuilder.fromXDR(
     asEnvelopeXdr(envelopeXdr),
     networkPassphrase,
-  ) as Transaction;
+  ) as Transaction | FeeBumpTransaction;
+
+const getInnerTransaction = (
+  transaction: Transaction | FeeBumpTransaction,
+): Transaction =>
+  transaction instanceof FeeBumpTransaction
+    ? transaction.innerTransaction
+    : transaction;
 
 describe(
   "[Testnet] InvokeContract channel accounts plugin",
@@ -87,9 +96,18 @@ describe(
       const plugin = createChannelAccountsPlugin({
         channels: [channel],
       });
+      const feeBumpPlugin = createFeeBumpPlugin({
+        networkConfig,
+        feeBumpConfig: {
+          source: sponsor.address(),
+          fee: "20000000",
+          signers: [sponsor.signer()],
+        },
+      });
 
       const pipeline = createInvokeContractPipeline({ networkConfig });
       pipeline.use(plugin);
+      pipeline.use(feeBumpPlugin);
 
       const xlmContractId = Asset.native().contractId(
         networkConfig.networkPassphrase,
@@ -115,8 +133,9 @@ describe(
         result.response.envelopeXdr,
         networkConfig.networkPassphrase,
       );
+      const innerTransaction = getInnerTransaction(transaction);
 
-      assertEquals(transaction.source, channel.address());
+      assertEquals(innerTransaction.source, channel.address());
       assertEquals(plugin.getChannels().map((item) => item.address()), [
         channel.address(),
       ]);

--- a/plugins/channel-accounts/src/shared/types.ts
+++ b/plugins/channel-accounts/src/shared/types.ts
@@ -35,7 +35,7 @@ export const CHANNEL_ACCOUNTS_PLUGIN_TARGETS = [
 ] as const satisfies readonly ChannelAccountsPluginTarget[];
 
 /**
- * Maximum number of channel accounts that can be opened in a single setup transaction.
+ * Maximum number of channel accounts handled in a single setup or close transaction batch.
  */
 export const MAX_CHANNELS_PER_TRANSACTION = 15;
 
@@ -90,7 +90,7 @@ export type ChannelAccountsPluginControls = {
 };
 
 /**
- * Arguments for opening and funding new channel accounts.
+ * Arguments for opening new channel accounts.
  */
 export type OpenChannelsArgs = {
   numberOfChannels: number;

--- a/plugins/channel-accounts/src/tools/channel-accounts.integration.test.ts
+++ b/plugins/channel-accounts/src/tools/channel-accounts.integration.test.ts
@@ -74,8 +74,12 @@ describe("ChannelAccounts integration", disableSanitizeConfig, () => {
       });
 
       assertEquals(channels.length, 2);
-      await Promise.all(
-        channels.map((channel) => rpc.getAccount(channel.address())),
+      const accountEntries = await Promise.all(
+        channels.map((channel) => rpc.getAccountEntry(channel.address())),
+      );
+      assertEquals(
+        accountEntries.map((entry) => entry.balance().toString()),
+        ["0", "0"],
       );
 
       await ChannelAccounts.close({

--- a/plugins/channel-accounts/src/tools/channel-accounts.integration.test.ts
+++ b/plugins/channel-accounts/src/tools/channel-accounts.integration.test.ts
@@ -1,29 +1,21 @@
 import { disableSanitizeConfig } from "colibri-internal/tests/disable-sanitize-config.ts";
 import { assertEquals, assertExists, assertRejects } from "@std/assert";
-import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { beforeAll, describe, it } from "@std/testing/bdd";
 import {
   initializeWithFriendbot,
   LocalSigner,
   NativeAccount,
   NetworkConfig,
-  type NetworkConfig as NetworkConfigType,
   StrKey,
   type TransactionConfig,
 } from "@colibri/core";
-import { StellarTestLedger } from "@colibri/test-tooling";
 import { Server } from "stellar-sdk/rpc";
 import { ChannelAccounts } from "@/index.ts";
 
-describe("ChannelAccounts integration", disableSanitizeConfig, () => {
-  const ledger = new StellarTestLedger({
-    containerName: `colibri-plugin-channel-accounts-${crypto.randomUUID()}`,
-    containerImageVersion: "latest",
-    logLevel: "silent",
-  });
-
+describe("[Testnet] ChannelAccounts integration", disableSanitizeConfig, () => {
   const sponsor = NativeAccount.fromMasterSigner(LocalSigner.generateRandom());
+  const networkConfig = NetworkConfig.TestNet();
 
-  let networkConfig: NetworkConfigType;
   let sponsorConfig: TransactionConfig;
   let rpc: Server;
 
@@ -37,13 +29,9 @@ describe("ChannelAccounts integration", disableSanitizeConfig, () => {
         rpcUrl: networkConfig.rpcUrl!,
         allowHttp: networkConfig.allowHttp,
       },
-    );
+  );
 
   beforeAll(async () => {
-    await ledger.start();
-
-    const networkDetails = await ledger.getNetworkDetails();
-    networkConfig = NetworkConfig.CustomNet(networkDetails);
     rpc = new Server(networkConfig.rpcUrl!, {
       allowHttp: networkConfig.allowHttp ?? false,
     });
@@ -56,11 +44,6 @@ describe("ChannelAccounts integration", disableSanitizeConfig, () => {
       source: sponsor.address(),
       signers: [sponsor.signer()],
     };
-  });
-
-  afterAll(async () => {
-    await ledger.stop();
-    await ledger.destroy();
   });
 
   describe("ChannelAccounts", () => {

--- a/plugins/channel-accounts/src/tools/channel-accounts.ts
+++ b/plugins/channel-accounts/src/tools/channel-accounts.ts
@@ -4,8 +4,11 @@ import {
   createClassicTransactionPipeline,
   LocalSigner,
   NativeAccount,
+  type Signer,
+  StrKey,
 } from "@colibri/core";
-import { Operation } from "stellar-sdk";
+import { Operation, TransactionBuilder, type Transaction } from "stellar-sdk";
+import { Api, Server } from "stellar-sdk/rpc";
 import { appendUniqueSigners } from "@/shared/signers.ts";
 import {
   type ChannelAccount,
@@ -27,17 +30,112 @@ const createClassicPipelineArgs = <
     ? { networkConfig: args.networkConfig, rpc: args.rpc }
     : { networkConfig: args.networkConfig };
 
+const resolveRpc = <
+  Args extends {
+    networkConfig: OpenChannelsArgs["networkConfig"];
+    rpc?: OpenChannelsArgs["rpc"];
+  },
+>(
+  args: Args,
+) =>
+  args.rpc ??
+  new Server(args.networkConfig.rpcUrl!, {
+    allowHttp: args.networkConfig.allowHttp ?? false,
+  });
+
 const createChannelAccount = (): ChannelAccount =>
   NativeAccount.fromMasterSigner(LocalSigner.generateRandom());
 
-const DEFAULT_CHANNEL_STARTING_BALANCE = "10";
+const sponsorCanSignChannel = async (
+  rpc: Server,
+  sponsor: ChannelAccount,
+  channel: ChannelAccount,
+): Promise<boolean> => {
+  const accountEntry = await rpc.getAccountEntry(channel.address());
+
+  return accountEntry.signers().some((signer) => {
+    try {
+      return (
+        signer.weight() > 0 &&
+        StrKey.encodeEd25519PublicKey(signer.key().ed25519()) ===
+          sponsor.address()
+      );
+    } catch {
+      return false;
+    }
+  });
+};
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const signTransactionWithSigners = async (
+  transaction: Transaction,
+  signers: readonly Signer[],
+  networkPassphrase: string,
+): Promise<Transaction> => {
+  let signedTransaction = transaction;
+
+  for (const signer of signers) {
+    signedTransaction = TransactionBuilder.fromXDR(
+      await signer.signTransaction(signedTransaction),
+      networkPassphrase,
+    ) as Transaction;
+  }
+
+  return signedTransaction;
+};
+
+const submitTransaction = async (
+  rpc: Server,
+  transaction: Transaction,
+  timeoutInSeconds: number,
+): Promise<void> => {
+  const sendResponse = await rpc.sendTransaction(transaction);
+
+  if (sendResponse.status === "ERROR") {
+    throw new Error(
+      `Transaction processing error: ${sendResponse.errorResult ?? "unknown"}`,
+    );
+  }
+
+  if (sendResponse.status === "DUPLICATE") {
+    throw new Error(`Duplicate transaction: ${sendResponse.hash}`);
+  }
+
+  if (sendResponse.status === "TRY_AGAIN_LATER") {
+    throw new Error(`Transaction throttled: ${sendResponse.hash}`);
+  }
+
+  if (sendResponse.status !== "PENDING") {
+    throw new Error(`Unexpected transaction status: ${sendResponse.status}`);
+  }
+
+  const deadline = Date.now() + timeoutInSeconds * 1000;
+
+  while (Date.now() < deadline) {
+    const response = await rpc.getTransaction(sendResponse.hash);
+
+    if (response.status === Api.GetTransactionStatus.SUCCESS) {
+      return;
+    }
+
+    if (response.status === Api.GetTransactionStatus.FAILED) {
+      throw new Error(`Transaction failed: ${sendResponse.hash}`);
+    }
+
+    await delay(500);
+  }
+
+  throw new Error(`Transaction timed out: ${sendResponse.hash}`);
+};
 
 /**
  * Opens and closes sponsored Stellar channel accounts for later pipeline reuse.
  */
 export class ChannelAccounts {
   /**
-   * Opens, funds, and optionally augments a bounded set of channel accounts.
+   * Opens and optionally augments a bounded set of channel accounts.
    *
    * @param args - Channel creation arguments
    * @returns The created channel accounts, each paired with its signer
@@ -98,7 +196,7 @@ export class ChannelAccounts {
           Operation.createAccount({
             source: sponsor.address(),
             destination: channel.address(),
-            startingBalance: DEFAULT_CHANNEL_STARTING_BALANCE,
+            startingBalance: "0",
           }),
         ];
 
@@ -184,24 +282,33 @@ export class ChannelAccounts {
     if (channels.length === 0) return;
 
     try {
-      const pipeline = createClassicTransactionPipeline(
-        createClassicPipelineArgs({ networkConfig, rpc }),
-      );
+      const closeRpc = resolveRpc({ networkConfig, rpc });
 
       for (const channel of channels) {
-        await pipeline.run({
-          operations: [
+        const signers = await sponsorCanSignChannel(closeRpc, sponsor, channel)
+          ? appendUniqueSigners(config.signers, sponsor.signer())
+          : appendUniqueSigners(config.signers, channel.signer());
+        const sourceAccount = await closeRpc.getAccount(config.source);
+        const transaction = new TransactionBuilder(sourceAccount, {
+          fee: config.fee,
+          networkPassphrase: networkConfig.networkPassphrase,
+        })
+          .addOperation(
             Operation.accountMerge({
               source: channel.address(),
               destination: sponsor.address(),
             }),
-          ],
-          config: {
-            ...config,
-            source: channel.address(),
-            signers: appendUniqueSigners(config.signers, channel.signer()),
-          },
-        });
+          )
+          .setTimeout(config.timeout)
+          .build();
+
+        const signedTransaction = await signTransactionWithSigners(
+          transaction,
+          signers,
+          networkConfig.networkPassphrase,
+        );
+
+        await submitTransaction(closeRpc, signedTransaction, config.timeout);
       }
     } catch (error) {
       if (error instanceof ColibriError) throw error;

--- a/plugins/channel-accounts/src/tools/channel-accounts.ts
+++ b/plugins/channel-accounts/src/tools/channel-accounts.ts
@@ -7,8 +7,8 @@ import {
   type Signer,
   StrKey,
 } from "@colibri/core";
-import { Operation, TransactionBuilder, type Transaction } from "stellar-sdk";
-import { Api, Server } from "stellar-sdk/rpc";
+import { Operation } from "stellar-sdk";
+import { Server } from "stellar-sdk/rpc";
 import { appendUniqueSigners } from "@/shared/signers.ts";
 import {
   type ChannelAccount,
@@ -66,69 +66,30 @@ const sponsorCanSignChannel = async (
   });
 };
 
-const delay = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms));
-
-const signTransactionWithSigners = async (
-  transaction: Transaction,
-  signers: readonly Signer[],
-  networkPassphrase: string,
-): Promise<Transaction> => {
-  let signedTransaction = transaction;
-
-  for (const signer of signers) {
-    signedTransaction = TransactionBuilder.fromXDR(
-      await signer.signTransaction(signedTransaction),
+const createChannelProxySigner = (
+  signer: Signer,
+  channel: ChannelAccount,
+): Signer => ({
+  publicKey: () => channel.address(),
+  sign: (data) => signer.sign(data),
+  signTransaction: (transaction) => signer.signTransaction(transaction),
+  signSorobanAuthEntry: (authEntry, validUntilLedgerSeq, networkPassphrase) =>
+    signer.signSorobanAuthEntry(
+      authEntry,
+      validUntilLedgerSeq,
       networkPassphrase,
-    ) as Transaction;
-  }
+    ),
+  signsFor: (target) => target === channel.address(),
+});
 
-  return signedTransaction;
-};
-
-const submitTransaction = async (
-  rpc: Server,
-  transaction: Transaction,
-  timeoutInSeconds: number,
-): Promise<void> => {
-  const sendResponse = await rpc.sendTransaction(transaction);
-
-  if (sendResponse.status === "ERROR") {
-    throw new Error(
-      `Transaction processing error: ${sendResponse.errorResult ?? "unknown"}`,
-    );
-  }
-
-  if (sendResponse.status === "DUPLICATE") {
-    throw new Error(`Duplicate transaction: ${sendResponse.hash}`);
-  }
-
-  if (sendResponse.status === "TRY_AGAIN_LATER") {
-    throw new Error(`Transaction throttled: ${sendResponse.hash}`);
-  }
-
-  if (sendResponse.status !== "PENDING") {
-    throw new Error(`Unexpected transaction status: ${sendResponse.status}`);
-  }
-
-  const deadline = Date.now() + timeoutInSeconds * 1000;
-
-  while (Date.now() < deadline) {
-    const response = await rpc.getTransaction(sendResponse.hash);
-
-    if (response.status === Api.GetTransactionStatus.SUCCESS) {
-      return;
-    }
-
-    if (response.status === Api.GetTransactionStatus.FAILED) {
-      throw new Error(`Transaction failed: ${sendResponse.hash}`);
-    }
-
-    await delay(500);
-  }
-
-  throw new Error(`Transaction timed out: ${sendResponse.hash}`);
-};
+const chunkChannels = (
+  channels: readonly ChannelAccount[],
+  size: number,
+): ChannelAccount[][] =>
+  Array.from(
+    { length: Math.ceil(channels.length / size) },
+    (_, index) => channels.slice(index * size, (index + 1) * size),
+  );
 
 /**
  * Opens and closes sponsored Stellar channel accounts for later pipeline reuse.
@@ -282,33 +243,36 @@ export class ChannelAccounts {
     if (channels.length === 0) return;
 
     try {
+      const pipeline = createClassicTransactionPipeline(
+        createClassicPipelineArgs({ networkConfig, rpc }),
+      );
       const closeRpc = resolveRpc({ networkConfig, rpc });
+      const sponsorSigner = sponsor.signer();
 
-      for (const channel of channels) {
-        const signers = await sponsorCanSignChannel(closeRpc, sponsor, channel)
-          ? appendUniqueSigners(config.signers, sponsor.signer())
-          : appendUniqueSigners(config.signers, channel.signer());
-        const sourceAccount = await closeRpc.getAccount(config.source);
-        const transaction = new TransactionBuilder(sourceAccount, {
-          fee: config.fee,
-          networkPassphrase: networkConfig.networkPassphrase,
-        })
-          .addOperation(
+      for (const channelBatch of chunkChannels(
+        channels,
+        MAX_CHANNELS_PER_TRANSACTION,
+      )) {
+        const closeSigners = await Promise.all(
+          channelBatch.map(async (channel) =>
+            await sponsorCanSignChannel(closeRpc, sponsor, channel)
+              ? createChannelProxySigner(sponsorSigner, channel)
+              : channel.signer()
+          ),
+        );
+
+        await pipeline.run({
+          operations: channelBatch.map((channel) =>
             Operation.accountMerge({
               source: channel.address(),
               destination: sponsor.address(),
-            }),
-          )
-          .setTimeout(config.timeout)
-          .build();
-
-        const signedTransaction = await signTransactionWithSigners(
-          transaction,
-          signers,
-          networkConfig.networkPassphrase,
-        );
-
-        await submitTransaction(closeRpc, signedTransaction, config.timeout);
+            })
+          ),
+          config: {
+            ...config,
+            signers: appendUniqueSigners(config.signers, ...closeSigners),
+          },
+        });
       }
     } catch (error) {
       if (error instanceof ColibriError) throw error;

--- a/plugins/channel-accounts/src/tools/channel-accounts.ts
+++ b/plugins/channel-accounts/src/tools/channel-accounts.ts
@@ -4,10 +4,11 @@ import {
   createClassicTransactionPipeline,
   LocalSigner,
   NativeAccount,
+  type SignableTransaction,
   type Signer,
   StrKey,
 } from "@colibri/core";
-import { Operation } from "stellar-sdk";
+import { Operation, type xdr } from "stellar-sdk";
 import { Server } from "stellar-sdk/rpc";
 import { appendUniqueSigners } from "@/shared/signers.ts";
 import {
@@ -66,13 +67,30 @@ const sponsorCanSignChannel = async (
   });
 };
 
+type SignableTransactionWithSignatures = SignableTransaction & {
+  signatures: xdr.DecoratedSignature[];
+  toXDR(format: "base64"): string;
+};
+
 const createChannelProxySigner = (
   signer: Signer,
   channel: ChannelAccount,
-): Signer => ({
+): Signer => {
+  const signerHint = StrKey.decodeEd25519PublicKey(signer.publicKey()).slice(-4);
+
+  return {
   publicKey: () => channel.address(),
   sign: (data) => signer.sign(data),
-  signTransaction: (transaction) => signer.signTransaction(transaction),
+  signTransaction: (transaction) => {
+    const signableTransaction = transaction as SignableTransactionWithSignatures;
+    const alreadySigned = signableTransaction.signatures.some((signature) =>
+      signature.hint().every((byte, index) => byte === signerHint[index])
+    );
+
+    return alreadySigned
+      ? signableTransaction.toXDR("base64")
+      : signer.signTransaction(transaction);
+  },
   signSorobanAuthEntry: (authEntry, validUntilLedgerSeq, networkPassphrase) =>
     signer.signSorobanAuthEntry(
       authEntry,
@@ -80,7 +98,8 @@ const createChannelProxySigner = (
       networkPassphrase,
     ),
   signsFor: (target) => target === channel.address(),
-});
+  };
+};
 
 const chunkChannels = (
   channels: readonly ChannelAccount[],

--- a/plugins/channel-accounts/src/tools/channel-accounts.ts
+++ b/plugins/channel-accounts/src/tools/channel-accounts.ts
@@ -2,14 +2,8 @@ import {
   assertRequiredArgs,
   ColibriError,
   createClassicTransactionPipeline,
-  LocalSigner,
-  NativeAccount,
-  type SignableTransaction,
-  type Signer,
-  StrKey,
 } from "@colibri/core";
-import { Operation, type xdr } from "stellar-sdk";
-import { Server } from "stellar-sdk/rpc";
+import { Operation } from "stellar-sdk";
 import { appendUniqueSigners } from "@/shared/signers.ts";
 import {
   type ChannelAccount,
@@ -17,98 +11,15 @@ import {
   MAX_CHANNELS_PER_TRANSACTION,
   type OpenChannelsArgs,
 } from "@/shared/types.ts";
+import {
+  chunkChannels,
+  createChannelAccount,
+  createChannelProxySigner,
+  createClassicPipelineArgs,
+  resolveRpc,
+  sponsorCanSignChannel,
+} from "@/tools/helpers.ts";
 import * as E from "@/shared/error.ts";
-
-const createClassicPipelineArgs = <
-  Args extends {
-    networkConfig: OpenChannelsArgs["networkConfig"];
-    rpc?: OpenChannelsArgs["rpc"];
-  },
->(
-  args: Args,
-) =>
-  args.rpc
-    ? { networkConfig: args.networkConfig, rpc: args.rpc }
-    : { networkConfig: args.networkConfig };
-
-const resolveRpc = <
-  Args extends {
-    networkConfig: OpenChannelsArgs["networkConfig"];
-    rpc?: OpenChannelsArgs["rpc"];
-  },
->(
-  args: Args,
-) =>
-  args.rpc ??
-  new Server(args.networkConfig.rpcUrl!, {
-    allowHttp: args.networkConfig.allowHttp ?? false,
-  });
-
-const createChannelAccount = (): ChannelAccount =>
-  NativeAccount.fromMasterSigner(LocalSigner.generateRandom());
-
-const sponsorCanSignChannel = async (
-  rpc: Server,
-  sponsor: ChannelAccount,
-  channel: ChannelAccount,
-): Promise<boolean> => {
-  const accountEntry = await rpc.getAccountEntry(channel.address());
-
-  return accountEntry.signers().some((signer) => {
-    try {
-      return (
-        signer.weight() > 0 &&
-        StrKey.encodeEd25519PublicKey(signer.key().ed25519()) ===
-          sponsor.address()
-      );
-    } catch {
-      return false;
-    }
-  });
-};
-
-type SignableTransactionWithSignatures = SignableTransaction & {
-  signatures: xdr.DecoratedSignature[];
-  toXDR(format: "base64"): string;
-};
-
-const createChannelProxySigner = (
-  signer: Signer,
-  channel: ChannelAccount,
-): Signer => {
-  const signerHint = StrKey.decodeEd25519PublicKey(signer.publicKey()).slice(-4);
-
-  return {
-  publicKey: () => channel.address(),
-  sign: (data) => signer.sign(data),
-  signTransaction: (transaction) => {
-    const signableTransaction = transaction as SignableTransactionWithSignatures;
-    const alreadySigned = signableTransaction.signatures.some((signature) =>
-      signature.hint().every((byte, index) => byte === signerHint[index])
-    );
-
-    return alreadySigned
-      ? signableTransaction.toXDR("base64")
-      : signer.signTransaction(transaction);
-  },
-  signSorobanAuthEntry: (authEntry, validUntilLedgerSeq, networkPassphrase) =>
-    signer.signSorobanAuthEntry(
-      authEntry,
-      validUntilLedgerSeq,
-      networkPassphrase,
-    ),
-  signsFor: (target) => target === channel.address(),
-  };
-};
-
-const chunkChannels = (
-  channels: readonly ChannelAccount[],
-  size: number,
-): ChannelAccount[][] =>
-  Array.from(
-    { length: Math.ceil(channels.length / size) },
-    (_, index) => channels.slice(index * size, (index + 1) * size),
-  );
 
 /**
  * Opens and closes sponsored Stellar channel accounts for later pipeline reuse.

--- a/plugins/channel-accounts/src/tools/channel-accounts.unit.test.ts
+++ b/plugins/channel-accounts/src/tools/channel-accounts.unit.test.ts
@@ -83,8 +83,8 @@ describe("ChannelAccounts unit behavior", () => {
     assertEquals(result, undefined);
   });
 
-  it("rethrows Colibri errors raised while closing channels", async () => {
-    const error = await assertRejects(
+  it("wraps invalid close runtime errors", async () => {
+    await assertRejects(
       async () =>
         await ChannelAccounts.close({
           channels: [channel],
@@ -92,10 +92,8 @@ describe("ChannelAccounts unit behavior", () => {
           networkConfig: {} as never,
           config,
         }),
-      ColibriError,
+      E.UNEXPECTED_ERROR,
     );
-
-    assertEquals(error instanceof E.UNEXPECTED_ERROR, false);
   });
 
   it("wraps unexpected errors raised while closing channels", async () => {

--- a/plugins/channel-accounts/src/tools/channel-accounts.unit.test.ts
+++ b/plugins/channel-accounts/src/tools/channel-accounts.unit.test.ts
@@ -83,8 +83,8 @@ describe("ChannelAccounts unit behavior", () => {
     assertEquals(result, undefined);
   });
 
-  it("wraps invalid close runtime errors", async () => {
-    await assertRejects(
+  it("rethrows Colibri errors raised while closing channels", async () => {
+    const error = await assertRejects(
       async () =>
         await ChannelAccounts.close({
           channels: [channel],
@@ -92,8 +92,10 @@ describe("ChannelAccounts unit behavior", () => {
           networkConfig: {} as never,
           config,
         }),
-      E.UNEXPECTED_ERROR,
+      ColibriError,
     );
+
+    assertEquals(error instanceof E.UNEXPECTED_ERROR, false);
   });
 
   it("wraps unexpected errors raised while closing channels", async () => {

--- a/plugins/channel-accounts/src/tools/helpers.ts
+++ b/plugins/channel-accounts/src/tools/helpers.ts
@@ -1,0 +1,99 @@
+import {
+  LocalSigner,
+  NativeAccount,
+  type SignableTransaction,
+  type Signer,
+  StrKey,
+} from "@colibri/core";
+import type { xdr } from "stellar-sdk";
+import { Server } from "stellar-sdk/rpc";
+import type {
+  ChannelAccount,
+  OpenChannelsArgs,
+} from "@/shared/types.ts";
+
+export const createClassicPipelineArgs = <
+  Args extends {
+    networkConfig: OpenChannelsArgs["networkConfig"];
+    rpc?: OpenChannelsArgs["rpc"];
+  },
+>(
+  args: Args,
+) =>
+  args.rpc
+    ? { networkConfig: args.networkConfig, rpc: args.rpc }
+    : { networkConfig: args.networkConfig };
+
+export const resolveRpc = <
+  Args extends {
+    networkConfig: OpenChannelsArgs["networkConfig"];
+    rpc?: OpenChannelsArgs["rpc"];
+  },
+>(
+  args: Args,
+) =>
+  args.rpc ??
+  new Server(args.networkConfig.rpcUrl!, {
+    allowHttp: args.networkConfig.allowHttp ?? false,
+  });
+
+export const createChannelAccount = (): ChannelAccount =>
+  NativeAccount.fromMasterSigner(LocalSigner.generateRandom());
+
+export const sponsorCanSignChannel = async (
+  rpc: Server,
+  sponsor: ChannelAccount,
+  channel: ChannelAccount,
+): Promise<boolean> => {
+  const accountEntry = await rpc.getAccountEntry(channel.address());
+
+  return accountEntry.signers().some((signer) => {
+    try {
+      return (
+        signer.weight() > 0 &&
+        StrKey.encodeEd25519PublicKey(signer.key().ed25519()) ===
+          sponsor.address()
+      );
+    } catch {
+      return false;
+    }
+  });
+};
+
+type SignableTransactionWithSignatures = SignableTransaction & {
+  signatures: xdr.DecoratedSignature[];
+  toXDR(format: "base64"): string;
+};
+
+export const createChannelProxySigner = (
+  signer: Signer,
+  channel: ChannelAccount,
+): Signer => {
+  const signerHint = StrKey.decodeEd25519PublicKey(signer.publicKey()).slice(-4);
+
+  return {
+    publicKey: () => channel.address(),
+    sign: signer.sign.bind(signer),
+    signTransaction: (transaction) => {
+      const signableTransaction = transaction as SignableTransactionWithSignatures;
+      const alreadySigned = signableTransaction.signatures.some((signature) =>
+        signature.hint().every((byte, index) => byte === signerHint[index])
+      );
+
+      return alreadySigned
+        ? signableTransaction.toXDR("base64")
+        : signer.signTransaction(transaction);
+    },
+    signSorobanAuthEntry: signer.signSorobanAuthEntry.bind(signer),
+    signsFor: (target) => target === channel.address(),
+  };
+};
+
+export const chunkChannels = (
+  channels: readonly ChannelAccount[],
+  size: number,
+): ChannelAccount[][] =>
+  Array.from(
+    { length: Math.ceil(channels.length / size) },
+    (_, index) => channels.slice(index * size, (index + 1) * size),
+  );

--- a/plugins/channel-accounts/src/tools/helpers.unit.test.ts
+++ b/plugins/channel-accounts/src/tools/helpers.unit.test.ts
@@ -1,0 +1,183 @@
+import {
+  assert,
+  assertEquals,
+  assertInstanceOf,
+  assertNotStrictEquals,
+} from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { Buffer } from "buffer";
+import { Keypair, xdr } from "stellar-sdk";
+import { Server } from "stellar-sdk/rpc";
+import {
+  LocalSigner,
+  NativeAccount,
+  NetworkConfig,
+  type Signer,
+  StrKey,
+} from "@colibri/core";
+import type { ChannelAccount } from "@/shared/types.ts";
+import {
+  chunkChannels,
+  createChannelAccount,
+  createChannelProxySigner,
+  createClassicPipelineArgs,
+  resolveRpc,
+  sponsorCanSignChannel,
+} from "@/tools/helpers.ts";
+
+const sponsor = NativeAccount.fromMasterSigner(LocalSigner.generateRandom());
+const channel = NativeAccount.fromMasterSigner(LocalSigner.generateRandom());
+
+describe("ChannelAccounts helpers", () => {
+  it("creates classic pipeline args with and without an rpc override", () => {
+    const networkConfig = NetworkConfig.TestNet();
+    const rpc = new Server("https://override.example.com");
+
+    assertEquals(createClassicPipelineArgs({ networkConfig, rpc }), {
+      networkConfig,
+      rpc,
+    });
+    assertEquals(createClassicPipelineArgs({ networkConfig }), {
+      networkConfig,
+    });
+  });
+
+  it("resolves the provided rpc or creates a new one from network config", () => {
+    const networkConfig = NetworkConfig.TestNet();
+    const providedRpc = new Server("https://override.example.com");
+
+    assertEquals(resolveRpc({ networkConfig, rpc: providedRpc }), providedRpc);
+
+    const resolvedRpc = resolveRpc({ networkConfig });
+    assertInstanceOf(resolvedRpc, Server);
+    assertNotStrictEquals(resolvedRpc, providedRpc);
+  });
+
+  it("creates a fresh channel account paired with its master signer", () => {
+    const created = createChannelAccount();
+
+    assertEquals(created.signer().publicKey(), created.address());
+    assert(created.address().startsWith("G"));
+  });
+
+  it("detects when the sponsor can sign for a channel", async () => {
+    const rpc = {
+      getAccountEntry() {
+        return Promise.resolve({
+          signers() {
+            return [{
+              weight: () => 1,
+              key: () => ({
+                ed25519: () =>
+                  StrKey.decodeEd25519PublicKey(sponsor.address()),
+              }),
+            }];
+          },
+        });
+      },
+    } as unknown as Server;
+
+    assertEquals(await sponsorCanSignChannel(rpc, sponsor, channel), true);
+  });
+
+  it("ignores malformed signer entries when checking sponsor authority", async () => {
+    const rpc = {
+      getAccountEntry() {
+        return Promise.resolve({
+          signers() {
+            return [{
+              weight: () => 1,
+              key: () => {
+                throw new Error("bad signer");
+              },
+            }];
+          },
+        });
+      },
+    } as unknown as Server;
+
+    assertEquals(await sponsorCanSignChannel(rpc, sponsor, channel), false);
+  });
+
+  it("proxies signer capabilities for channel-scoped signing", async () => {
+    const calls = {
+      sign: 0,
+      signTransaction: 0,
+      signSorobanAuthEntry: 0,
+    };
+    const fakeSigner: Signer = {
+      publicKey: () => sponsor.address(),
+      sign: (data) => {
+        calls.sign += 1;
+        return Buffer.from(data);
+      },
+      signTransaction: () => {
+        calls.signTransaction += 1;
+        return "signed-xdr";
+      },
+      signSorobanAuthEntry: (entry) => {
+        calls.signSorobanAuthEntry += 1;
+        return Promise.resolve(entry);
+      },
+      signsFor: () => true,
+    };
+
+    const proxySigner = createChannelProxySigner(fakeSigner, channel);
+    const forwardedData = Buffer.from("payload");
+    const sorobanEntry = {} as xdr.SorobanAuthorizationEntry;
+    const transactionXdr = await proxySigner.signTransaction({
+      signatures: [],
+      toXDR: () => "fresh-xdr",
+    } as never);
+
+    assertEquals(proxySigner.publicKey(), channel.address());
+    assertEquals(proxySigner.sign(forwardedData), forwardedData);
+    assertEquals(
+      await proxySigner.signSorobanAuthEntry(sorobanEntry, 123, "testnet"),
+      sorobanEntry,
+    );
+    assertEquals(proxySigner.signsFor(channel.address()), true);
+    assertEquals(proxySigner.signsFor(sponsor.address()), false);
+    assertEquals(transactionXdr, "signed-xdr");
+    assertEquals(calls.sign, 1);
+    assertEquals(calls.signTransaction, 1);
+    assertEquals(calls.signSorobanAuthEntry, 1);
+  });
+
+  it("reuses the existing transaction xdr when the proxy signer hint is already present", async () => {
+    const signerHint = Keypair.fromPublicKey(sponsor.address()).signatureHint();
+    const fakeSigner: Signer = {
+      publicKey: () => sponsor.address(),
+      sign: (data) => data,
+      signTransaction: () => {
+        throw new Error("should not sign twice");
+      },
+      signSorobanAuthEntry: (entry) => Promise.resolve(entry),
+      signsFor: () => true,
+    };
+
+    const proxySigner = createChannelProxySigner(fakeSigner, channel);
+    const signedTransactionXdr = await proxySigner.signTransaction({
+      signatures: [
+        new xdr.DecoratedSignature({
+          hint: signerHint,
+          signature: Buffer.from("already-signed"),
+        }),
+      ],
+      toXDR: () => "already-signed-xdr",
+    } as never);
+
+    assertEquals(signedTransactionXdr, "already-signed-xdr");
+  });
+
+  it("chunks channels into bounded batches", () => {
+    const otherChannel = createChannelAccount();
+
+    assertEquals(
+      chunkChannels([sponsor, channel, otherChannel] as ChannelAccount[], 2).map((
+        batch,
+      ) => batch.length),
+      [2, 1],
+    );
+  });
+});


### PR DESCRIPTION
## Summary

This updates `@colibri/plugin-channel-accounts` so newly opened channels start with `0` balance instead of `10`.

## Changes

- removes the `DEFAULT_CHANNEL_STARTING_BALANCE` constant
- hardcodes channel creation to `startingBalance: "0"`
- updates `ChannelAccounts.close(...)` so zero-balance channels can still be merged back correctly
- keeps the sponsor-as-signer close path working
- updates package docs to reflect zero-balance channels and fee-bump composition
- bumps `@colibri/plugin-channel-accounts` from `0.1.0` to `0.2.0`

## Verification

- `deno lint plugins/channel-accounts`
- `deno task check`
- `deno check plugins/channel-accounts/src/plugin/invoke-contract.testnet.integration.test.ts`
- `deno test -A plugins/channel-accounts/src/tools/channel-accounts.unit.test.ts plugins/channel-accounts/src/plugin/index.unit.test.ts`
- `deno test -A plugins/channel-accounts/src/tools/channel-accounts.integration.test.ts`
- `deno test -A plugins/channel-accounts/src/plugin/classic-transaction.integration.test.ts`
