### PR TITLE
Add LedgerEntries RPC access layer

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -26,9 +26,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: 2.7.11
 
       # Uncomment this step to verify the use of 'deno fmt' on each commit.
       # - name: Verify formatting

--- a/core/README.md
+++ b/core/README.md
@@ -233,6 +233,37 @@ known contract id, wasm, or deployed contract metadata. It exposes its
 `invokePipe` and `readPipe` publicly, which makes it the right seam for advanced
 pipeline plugin composition.
 
+## Ledger entries
+
+`LedgerEntries` provides typed RPC reads for well-known Stellar ledger entries
+without forcing callers to assemble `LedgerKey` XDR or manually walk the
+returned entry XDR.
+
+```ts
+const ledger = new LedgerEntries({ networkConfig });
+
+const account = await ledger.account({ accountId });
+const trustline = await ledger.trustline({ accountId, asset });
+const instance = await ledger.contractInstance({ contractId });
+
+account.balance;
+trustline.limit;
+instance.executable;
+instance.xdr; // parsed RPC entry for advanced inspection
+```
+
+For lower-level workflows, the branded key builders remain available as
+standalone exports and still return plain `xdr.LedgerKey` values at runtime:
+
+```ts
+const [account, config] = await ledger.getMany([
+  buildAccountLedgerKey({ accountId }),
+  buildConfigSettingLedgerKey({
+    configSettingId: "configSettingContractMaxSizeBytes",
+  }),
+] as const);
+```
+
 ### StellarAssetContract
 
 `StellarAssetContract` is the domain-specific client for CAP-0046-06 Stellar

--- a/core/account/native/index.ts
+++ b/core/account/native/index.ts
@@ -1,19 +1,24 @@
-import { Account, Keypair, MuxedAccount, xdr } from "stellar-sdk";
+import { Account, MuxedAccount } from "stellar-sdk";
 import { assert } from "@/common/assert/assert.ts";
 import { StrKey } from "@/strkeys/index.ts";
 import { isMuxedId } from "@/common/type-guards/is-muxed-id.ts";
 import type { Ed25519PublicKey, MuxedAddress } from "@/strkeys/types.ts";
+import type { TrustlineAssetLike } from "@/common/types/index.ts";
+import {
+  buildAccountLedgerKey,
+  buildTrustlineLedgerKey,
+} from "@/ledger-entries/keys.ts";
 import type {
-  LedgerKeyLike,
-  TrustlineAssetLike,
-} from "@/common/types/index.ts";
+  AccountLedgerKey,
+  TrustlineLedgerKey,
+} from "@/ledger-entries/types.ts";
 import type { Signer } from "@/signer/types.ts";
 import * as E from "@/account/native/error.ts";
 import type { INativeAccount, MuxedId } from "@/account/native/types.ts";
 import type {
   StellarAddress,
-  WithSigner,
   WithoutSigner,
+  WithSigner,
 } from "@/account/types.ts";
 
 /**
@@ -28,7 +33,7 @@ export class NativeAccount implements INativeAccount {
   private constructor(publicKey: Ed25519PublicKey) {
     assert(
       StrKey.isValidEd25519PublicKey(publicKey),
-      new E.INVALID_ED25519_PUBLIC_KEY(publicKey)
+      new E.INVALID_ED25519_PUBLIC_KEY(publicKey),
     );
 
     this._publicKey = publicKey;
@@ -43,7 +48,7 @@ export class NativeAccount implements INativeAccount {
   static fromAddress(address: StellarAddress): WithoutSigner<NativeAccount> {
     assert(
       StrKey.isEd25519PublicKey(address),
-      new E.UNSUPPORTED_ADDRESS_TYPE(address)
+      new E.UNSUPPORTED_ADDRESS_TYPE(address),
     );
     return new NativeAccount(address) as WithoutSigner<NativeAccount>;
   }
@@ -55,7 +60,7 @@ export class NativeAccount implements INativeAccount {
    * @returns A native account without an attached signer.
    */
   static fromPublicKey(
-    address: Ed25519PublicKey
+    address: Ed25519PublicKey,
   ): WithoutSigner<NativeAccount> {
     return new NativeAccount(address) as WithoutSigner<NativeAccount>;
   }
@@ -84,7 +89,7 @@ export class NativeAccount implements INativeAccount {
 
     assert(
       StrKey.isValidMuxedAddress(muxedAddress),
-      new E.INVALID_MUXED_ADDRESS_GENERATED(muxedAddress, id, this._publicKey)
+      new E.INVALID_MUXED_ADDRESS_GENERATED(muxedAddress, id, this._publicKey),
     );
 
     return muxedAddress as MuxedAddress;
@@ -95,14 +100,8 @@ export class NativeAccount implements INativeAccount {
    *
    * @returns Account ledger key for direct ledger lookups.
    */
-  getAccountLedgerKey(): LedgerKeyLike {
-    const ledgerKey = xdr.LedgerKey.account(
-      new xdr.LedgerKeyAccount({
-        accountId: Keypair.fromPublicKey(this._publicKey).xdrPublicKey(),
-      })
-    );
-
-    return ledgerKey;
+  getAccountLedgerKey(): AccountLedgerKey {
+    return buildAccountLedgerKey({ accountId: this._publicKey });
   }
 
   /**
@@ -111,15 +110,11 @@ export class NativeAccount implements INativeAccount {
    * @param asset - Trustline asset to resolve.
    * @returns Trustline ledger key for direct ledger lookups.
    */
-  getTrustlineLedgerKey(asset: TrustlineAssetLike): LedgerKeyLike {
-    const trustlineLedgerKey = xdr.LedgerKey.trustline(
-      new xdr.LedgerKeyTrustLine({
-        accountId: Keypair.fromPublicKey(this._publicKey).xdrAccountId(),
-        asset: asset.toTrustLineXDRObject() as xdr.TrustLineAsset,
-      })
-    );
-
-    return trustlineLedgerKey;
+  getTrustlineLedgerKey(asset: TrustlineAssetLike): TrustlineLedgerKey {
+    return buildTrustlineLedgerKey({
+      accountId: this._publicKey,
+      asset,
+    });
   }
 
   // ----------------
@@ -134,7 +129,7 @@ export class NativeAccount implements INativeAccount {
    */
   static fromMasterSigner(signer: Signer): WithSigner<NativeAccount> {
     return NativeAccount.fromAddress(signer.publicKey()).withMasterSigner(
-      signer
+      signer,
     );
   }
 

--- a/core/account/native/types.ts
+++ b/core/account/native/types.ts
@@ -1,9 +1,10 @@
 import type { Ed25519PublicKey, MuxedAddress } from "@/strkeys/types.ts";
 import type { Account } from "@/account/types.ts";
+import type { TrustlineAssetLike } from "@/common/types/index.ts";
 import type {
-  LedgerKeyLike,
-  TrustlineAssetLike,
-} from "@/common/types/index.ts";
+  AccountLedgerKey,
+  TrustlineLedgerKey,
+} from "@/ledger-entries/types.ts";
 
 /**
  * String-encoded muxed account id accepted by {@link NativeAccount.muxedAddress}.
@@ -19,7 +20,7 @@ export interface INativeAccount extends Account {
   /** Returns the muxed address generated for the provided id. */
   muxedAddress(id: MuxedId): MuxedAddress;
   /** Returns the ledger key for the account entry. */
-  getAccountLedgerKey(): LedgerKeyLike;
+  getAccountLedgerKey(): AccountLedgerKey;
   /** Returns the ledger key for the provided trustline asset. */
-  getTrustlineLedgerKey(asset: TrustlineAssetLike): LedgerKeyLike;
+  getTrustlineLedgerKey(asset: TrustlineAssetLike): TrustlineLedgerKey;
 }

--- a/core/account/types.ts
+++ b/core/account/types.ts
@@ -1,12 +1,13 @@
 import type {
+  ContractId,
   Ed25519PublicKey,
   MuxedAddress,
-  ContractId,
 } from "@/strkeys/types.ts";
+import type { TrustlineAssetLike } from "@/common/types/index.ts";
 import type {
-  LedgerKeyLike,
-  TrustlineAssetLike,
-} from "@/common/types/index.ts";
+  AccountLedgerKey,
+  TrustlineLedgerKey,
+} from "@/ledger-entries/types.ts";
 import type { MultiSigSchema, Signer } from "@/signer/types.ts";
 
 /**
@@ -21,13 +22,13 @@ export interface Account {
   /** Returns the canonical address represented by the account helper. */
   address(): StellarAddress;
   /** Builds the ledger key that identifies the account entry. */
-  getAccountLedgerKey(): LedgerKeyLike;
+  getAccountLedgerKey(): AccountLedgerKey;
   /**
    * Builds the ledger key for a trustline entry owned by this account.
    *
    * @param asset - Asset whose trustline should be addressed.
    */
-  getTrustlineLedgerKey(asset: TrustlineAssetLike): LedgerKeyLike;
+  getTrustlineLedgerKey(asset: TrustlineAssetLike): TrustlineLedgerKey;
 }
 
 /**

--- a/core/asset/sac/index.integration.test.ts
+++ b/core/asset/sac/index.integration.test.ts
@@ -26,7 +26,7 @@ describe("[Testnet] Stellar Asset Contract", disableSanitizeConfig, () => {
   const networkConfig = NetworkConfig.TestNet();
 
   // The RPC may sometimes take a while to reflect changes, so we use a longer timeout for the integration tests
-  // This seems to be specific to testnet.
+  // This seems to be specific to testnet, when using SDF's RPC and also near testnet upgrades.
   const wait = (ms = 500) => new Promise((resolve) => setTimeout(resolve, ms));
 
   const setupIssuerFlags = async (
@@ -78,7 +78,7 @@ describe("[Testnet] Stellar Asset Contract", disableSanitizeConfig, () => {
 
   const txConfig: TransactionConfig = {
     fee: "10000000", // 1 XLM
-    timeout: 30,
+    timeout: 60,
     source: issuer.address(),
     signers: [issuer.signer()],
   };

--- a/core/asset/sep11/error.ts
+++ b/core/asset/sep11/error.ts
@@ -1,0 +1,58 @@
+import { ColibriError } from "@/error/index.ts";
+
+export type Meta = {
+  cause: Error | null;
+  data: unknown;
+};
+
+export abstract class Sep11Error<
+  CodeType extends string,
+> extends ColibriError<CodeType, Meta> {
+  override readonly source = "@colibri/core/asset/sep11";
+  override readonly meta: Meta;
+
+  constructor(args: {
+    code: CodeType;
+    message: string;
+    details: string;
+    data: unknown;
+    cause?: Error;
+  }) {
+    const meta = {
+      cause: args.cause ?? null,
+      data: args.data,
+    };
+
+    super({
+      domain: "core",
+      source: "@colibri/core/asset/sep11",
+      code: args.code,
+      message: args.message,
+      details: args.details,
+      meta,
+    });
+
+    this.meta = meta;
+  }
+}
+
+export enum Code {
+  MISSING_ISSUER_FOR_NON_NATIVE_ASSET = "AST_SEP11_001",
+}
+
+export class MISSING_ISSUER_FOR_NON_NATIVE_ASSET extends Sep11Error<Code> {
+  constructor(code: string) {
+    super({
+      code: Code.MISSING_ISSUER_FOR_NON_NATIVE_ASSET,
+      message: `Issuer required for non-native asset: ${code}`,
+      details:
+        "A non-native SEP-11 asset string requires an issuer account id.",
+      data: { code },
+    });
+  }
+}
+
+export const ERROR_SEP11 = {
+  [Code.MISSING_ISSUER_FOR_NON_NATIVE_ASSET]:
+    MISSING_ISSUER_FOR_NON_NATIVE_ASSET,
+};

--- a/core/asset/sep11/index.ts
+++ b/core/asset/sep11/index.ts
@@ -12,6 +12,7 @@
 
 import { StrKey } from "@/strkeys/index.ts";
 import { regex } from "@/common/regex/index.ts";
+import { MISSING_ISSUER_FOR_NON_NATIVE_ASSET } from "@/asset/sep11/error.ts";
 import type { StellarAssetCanonicalString } from "@/asset/sep11/types.ts";
 /**
  * Check if a value is a valid SEP-11 StellarAssetCanonicalString.
@@ -128,7 +129,7 @@ export function toStellarAssetCanonicalString(
   }
 
   if (!issuer) {
-    throw new Error(`Issuer required for non-native asset: ${code}`);
+    throw new MISSING_ISSUER_FOR_NON_NATIVE_ASSET(code);
   }
 
   return `${code}:${issuer}` as StellarAssetCanonicalString;

--- a/core/common/helpers/bounded-array.ts
+++ b/core/common/helpers/bounded-array.ts
@@ -1,3 +1,9 @@
+import { ColibriError } from "@/error/index.ts";
+
+enum ErrorCode {
+  ARRAY_LENGTH_OUT_OF_BOUNDS = "HLP_BND_01",
+}
+
 /**
  * Helper to create a fixed-length tuple.
  * @internal
@@ -149,9 +155,21 @@ export function asBoundedArray<T, Min extends number, Max extends number>(
   max: Max
 ): BoundedArray<T, Min, Max> {
   if (!isBoundedArray(arr, min, max)) {
-    throw new Error(
-      `Array length ${arr.length} not in bounds [${min}, ${max}]`
-    );
+    throw ColibriError.unexpected({
+      domain: "helpers",
+      source: "@colibri/core/common/helpers/bounded-array",
+      code: ErrorCode.ARRAY_LENGTH_OUT_OF_BOUNDS,
+      message: `Array length ${arr.length} not in bounds [${min}, ${max}]`,
+      details:
+        "The provided array does not satisfy the required bounded length constraints.",
+      meta: {
+        data: {
+          length: arr.length,
+          min,
+          max,
+        },
+      },
+    });
   }
   return arr as unknown as BoundedArray<T, Min, Max>;
 }

--- a/core/common/helpers/failed-simulation-response.ts
+++ b/core/common/helpers/failed-simulation-response.ts
@@ -8,6 +8,20 @@ enum ErrorCode {
 }
 
 const baseErrorSource = "@colibri/core/helpers/failed-simulation-response";
+const contractIdLookupContext = {
+  domain: "helpers" as const,
+  code: ErrorCode.FAILED_TO_GET_ASSET_CONTRACT_ID,
+  source:
+    baseErrorSource +
+    "/getStellarAssetContractIdFromFailedSimulationResponse",
+  message: "Failed to get the contract Id from the simulation response!",
+  diagnostic: {
+    rootCause:
+      "When trying to identify the contract Id from the simulation response, an unexpected error occurred.",
+    suggestion:
+      "Ensure the simulation response is valid and contains the expected events. The reason behind the failure could be a different underlying cause than an already wrapped asset.",
+  },
+};
 
 export const getStellarAssetContractIdFromFailedSimulationResponse = (
   response: Api.SimulateTransactionErrorResponse
@@ -20,30 +34,26 @@ export const getStellarAssetContractIdFromFailedSimulationResponse = (
       : [];
 
     if (
-      dataVec &&
-      dataVec[0].value()?.toString() === "contract already exists"
+      dataVec?.[0]?.value()?.toString() === "contract already exists" &&
+      dataVec[1]?.bytes()
     ) {
       const contractId = Address.contract(dataVec[1].bytes()).toString();
       return contractId as ContractId;
     }
 
-    throw new Error(
-      "The simulation response does not indicate an already wrapped asset."
-    );
+    throw ColibriError.unexpected({
+      ...contractIdLookupContext,
+      details:
+        "The simulation response does not indicate an already wrapped asset.",
+      meta: {
+        data: {
+          simulationResponse: response,
+        },
+      },
+    });
   } catch (e) {
     throw ColibriError.fromUnknown(e, {
-      domain: "helpers",
-      code: ErrorCode.FAILED_TO_GET_ASSET_CONTRACT_ID,
-      source:
-        baseErrorSource +
-        "/getStellarAssetContractIdFromFailedSimulationResponse",
-      message: "Failed to get the contract Id from the simulation response!",
-      diagnostic: {
-        rootCause:
-          "When trying to identify the contract Id from the simulation response, an unexpected error occurred.",
-        suggestion:
-          "Ensure the simulation response is valid and contains the expected events. The reason behind the failure could be a different underlying cause than an already wrapped asset.",
-      },
+      ...contractIdLookupContext,
       meta: {
         data: {
           simulationResponse: response,

--- a/core/common/helpers/failed-simulation-response.unit.test.ts
+++ b/core/common/helpers/failed-simulation-response.unit.test.ts
@@ -1,0 +1,85 @@
+import {
+  assertEquals,
+  assertExists,
+  assertInstanceOf,
+  assertThrows,
+} from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { Buffer } from "buffer";
+import { xdr } from "stellar-sdk";
+import type { Api } from "stellar-sdk/rpc";
+import { getStellarAssetContractIdFromFailedSimulationResponse } from "@/common/helpers/failed-simulation-response.ts";
+import { ColibriError } from "@/error/index.ts";
+
+function makeSimulationErrorResponse(
+  values: xdr.ScVal[] | undefined,
+): Api.SimulateTransactionErrorResponse {
+  return {
+    events: values
+      ? [{
+        event: () => ({
+          body: () => ({
+            v0: () => ({
+              data: () => ({
+                vec: () => values,
+              }),
+            }),
+          }),
+        }),
+      }] as unknown as Api.SimulateTransactionErrorResponse["events"]
+      : undefined,
+  } as Api.SimulateTransactionErrorResponse;
+}
+
+describe("getStellarAssetContractIdFromFailedSimulationResponse", () => {
+  it("extracts the deployed Stellar Asset Contract id from the failure payload", () => {
+    const contractHash = Buffer.alloc(32, 7);
+    const response = makeSimulationErrorResponse([
+      xdr.ScVal.scvString("contract already exists"),
+      xdr.ScVal.scvBytes(contractHash),
+    ]);
+
+    const contractId = getStellarAssetContractIdFromFailedSimulationResponse(
+      response,
+    );
+
+    assertEquals(typeof contractId, "string");
+    assertEquals(contractId.length > 0, true);
+  });
+
+  it("throws a typed ColibriError when the response is not an already-wrapped asset failure", () => {
+    const response = makeSimulationErrorResponse(undefined);
+
+    const error = assertThrows(
+      () => getStellarAssetContractIdFromFailedSimulationResponse(response),
+      ColibriError,
+    );
+
+    assertInstanceOf(error, ColibriError);
+    assertEquals(error.code, "HLP_FSR_01");
+    assertEquals(
+      error.details,
+      "The simulation response does not indicate an already wrapped asset.",
+    );
+    assertEquals(
+      (error.meta?.data as { simulationResponse: Api.SimulateTransactionErrorResponse })
+        .simulationResponse,
+      response,
+    );
+  });
+
+  it("wraps malformed responses into the same typed ColibriError contract", () => {
+    const response = {
+      events: [{}],
+    } as Api.SimulateTransactionErrorResponse;
+
+    const error = assertThrows(
+      () => getStellarAssetContractIdFromFailedSimulationResponse(response),
+      ColibriError,
+    );
+
+    assertInstanceOf(error, ColibriError);
+    assertEquals(error.code, "HLP_FSR_01");
+    assertExists(error.meta?.cause);
+  });
+});

--- a/core/common/helpers/transaction.ts
+++ b/core/common/helpers/transaction.ts
@@ -14,6 +14,19 @@ export const getTransactionTimeout = (
   tx: Transaction | FeeBumpTransaction,
   unit: "seconds" | "milliseconds" = "seconds"
 ): number | undefined => {
+  const timeoutContext = {
+    domain: "helpers" as const,
+    source: baseErrorSource + "/getTransactionTimeout",
+    message:
+      "Failed to get transaction timeout from Transaction or FeeBumpTransaction!",
+    code: ErrorCode.FAILED_TO_GET_TRANSACTION_TIMEOUT,
+    meta: {
+      data: {
+        txXDR: softTryToXDR(() => tx.toXDR()),
+      },
+    },
+  };
+
   try {
     if (tx instanceof FeeBumpTransaction && "innerTransaction" in tx)
       tx = tx.innerTransaction;
@@ -27,20 +40,13 @@ export const getTransactionTimeout = (
         : undefined;
     }
 
-    throw new Error(`Unexpected transaction type!`);
-  } catch (e) {
-    throw ColibriError.fromUnknown(e, {
-      domain: "helpers",
-      source: baseErrorSource + "/getTransactionTimeout",
-      message:
-        "Failed to get transaction timeout from Transaction or FeeBumpTransaction!",
-      code: ErrorCode.FAILED_TO_GET_TRANSACTION_TIMEOUT,
-      meta: {
-        data: {
-          txXDR: softTryToXDR(() => tx.toXDR()),
-        },
-      },
+    throw ColibriError.unexpected({
+      ...timeoutContext,
+      details:
+        "The provided value is not a supported Transaction or FeeBumpTransaction instance.",
     });
+  } catch (e) {
+    throw ColibriError.fromUnknown(e, timeoutContext);
   }
 };
 

--- a/core/common/helpers/xdr/error.ts
+++ b/core/common/helpers/xdr/error.ts
@@ -26,6 +26,7 @@ export enum Code {
   FAILED_TO_PARSE_XDR = "HLP_XDR_09",
   UNSUPPORTED_SCVAL_TYPE = "HLP_XDR_10",
   UNKNOWN_SCVAL_TYPE = "HLP_XDR_11",
+  UNKNOWN_TRUSTLINE_ASSET_TYPE = "HLP_XDR_12",
 }
 
 export type MetaData = {
@@ -96,6 +97,21 @@ export class UNKNOWN_CHANGE_TRUST_ASSET_TYPE extends XdrHelperError {
     super({
       code: Code.UNKNOWN_CHANGE_TRUST_ASSET_TYPE,
       message: `Unknown ChangeTrustAsset type: ${assetType}`,
+      details:
+        "Expected assetTypeNative, assetTypeCreditAlphanum4, assetTypeCreditAlphanum12, or assetTypePoolShare",
+      data: { assetType },
+    });
+  }
+}
+
+/**
+ * Thrown when an unknown TrustLineAsset type is encountered.
+ */
+export class UNKNOWN_TRUSTLINE_ASSET_TYPE extends XdrHelperError {
+  constructor(assetType: string) {
+    super({
+      code: Code.UNKNOWN_TRUSTLINE_ASSET_TYPE,
+      message: `Unknown TrustLineAsset type: ${assetType}`,
       details:
         "Expected assetTypeNative, assetTypeCreditAlphanum4, assetTypeCreditAlphanum12, or assetTypePoolShare",
       data: { assetType },

--- a/core/common/helpers/xdr/parse-account-id.ts
+++ b/core/common/helpers/xdr/parse-account-id.ts
@@ -1,4 +1,5 @@
 import { StrKey } from "@/strkeys/index.ts";
+import type { Ed25519PublicKey } from "@/strkeys/types.ts";
 import type { xdr } from "stellar-sdk";
 
 /**
@@ -13,6 +14,6 @@ import type { xdr } from "stellar-sdk";
  * ```
  * @internal
  */
-export function parseAccountId(accountXdr: xdr.AccountId): string {
+export function parseAccountId(accountXdr: xdr.AccountId): Ed25519PublicKey {
   return StrKey.encodeEd25519PublicKey(accountXdr.ed25519());
 }

--- a/core/common/helpers/xdr/parse-trustline-asset.ts
+++ b/core/common/helpers/xdr/parse-trustline-asset.ts
@@ -1,0 +1,45 @@
+import { Buffer } from "buffer";
+import { StrKey } from "@/strkeys/index.ts";
+import { toStellarAssetCanonicalString } from "@/asset/sep11/index.ts";
+import type { ChangeTrustAssetString } from "@/common/helpers/xdr/parse-change-trust-asset.ts";
+import type { xdr } from "stellar-sdk";
+
+/**
+ * Parse a TrustLineAsset XDR to a readable string format.
+ *
+ * Unlike ChangeTrustAsset, pool-share trustlines carry a liquidity-pool id,
+ * not the original parameter payload.
+ *
+ * @param assetXdr - TrustLineAsset XDR object.
+ * @returns Asset/pool string in a friendly format.
+ *
+ * @internal
+ */
+export function parseTrustLineAsset(
+  assetXdr: xdr.TrustLineAsset,
+): ChangeTrustAssetString {
+  switch (assetXdr.switch().name) {
+    case "assetTypeNative":
+      return "native";
+
+    case "assetTypeCreditAlphanum4": {
+      const asset = assetXdr.alphaNum4();
+      const code = asset.assetCode().toString("utf8").replace(/\0/g, "");
+      const issuer = StrKey.encodeEd25519PublicKey(asset.issuer().ed25519());
+      return toStellarAssetCanonicalString(code, issuer);
+    }
+
+    case "assetTypeCreditAlphanum12": {
+      const asset = assetXdr.alphaNum12();
+      const code = asset.assetCode().toString("utf8").replace(/\0/g, "");
+      const issuer = StrKey.encodeEd25519PublicKey(asset.issuer().ed25519());
+      return toStellarAssetCanonicalString(code, issuer);
+    }
+
+    case "assetTypePoolShare":
+      return `pool:${StrKey.encodeLiquidityPool(Buffer.from(assetXdr.liquidityPoolId() as unknown as Uint8Array))}`;
+
+    default:
+      throw new Error(`Unsupported trustline asset type: ${assetXdr.switch().name}`);
+  }
+}

--- a/core/common/helpers/xdr/parse-trustline-asset.ts
+++ b/core/common/helpers/xdr/parse-trustline-asset.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "buffer";
 import { StrKey } from "@/strkeys/index.ts";
 import { toStellarAssetCanonicalString } from "@/asset/sep11/index.ts";
+import { UNKNOWN_TRUSTLINE_ASSET_TYPE } from "@/common/helpers/xdr/error.ts";
 import type { ChangeTrustAssetString } from "@/common/helpers/xdr/parse-change-trust-asset.ts";
 import type { xdr } from "stellar-sdk";
 
@@ -40,6 +41,6 @@ export function parseTrustLineAsset(
       return `pool:${StrKey.encodeLiquidityPool(Buffer.from(assetXdr.liquidityPoolId() as unknown as Uint8Array))}`;
 
     default:
-      throw new Error(`Unsupported trustline asset type: ${assetXdr.switch().name}`);
+      throw new UNKNOWN_TRUSTLINE_ASSET_TYPE(assetXdr.switch().name);
   }
 }

--- a/core/common/helpers/xdr/parse-trustline-asset.unit.test.ts
+++ b/core/common/helpers/xdr/parse-trustline-asset.unit.test.ts
@@ -1,0 +1,53 @@
+import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { Asset, Keypair, xdr } from "stellar-sdk";
+import { parseTrustLineAsset } from "@/common/helpers/xdr/parse-trustline-asset.ts";
+
+describe("parseTrustLineAsset", () => {
+  it("parses native assets", () => {
+    const asset = Asset.native();
+    const result = parseTrustLineAsset(
+      asset.toTrustLineXDRObject() as xdr.TrustLineAsset,
+    );
+
+    assertEquals(result, "native");
+  });
+
+  it("parses alpha-num assets", () => {
+    const issuer = Keypair.random().publicKey();
+
+    const alpha4 = parseTrustLineAsset(
+      new Asset("USD", issuer).toTrustLineXDRObject() as xdr.TrustLineAsset,
+    );
+    const alpha12 = parseTrustLineAsset(
+      new Asset("LONGASSETNAM", issuer)
+        .toTrustLineXDRObject() as xdr.TrustLineAsset,
+    );
+
+    assertEquals(alpha4, `USD:${issuer}`);
+    assertEquals(alpha12, `LONGASSETNAM:${issuer}`);
+  });
+
+  it("parses liquidity-pool share assets", () => {
+    const poolId = new Uint8Array(32).fill(9);
+    const asset = xdr.TrustLineAsset.assetTypePoolShare(
+      poolId as unknown as xdr.PoolId,
+    );
+
+    const result = parseTrustLineAsset(asset);
+
+    assertStringIncludes(result, "pool:");
+  });
+
+  it("throws for unsupported trustline asset types", () => {
+    assertThrows(
+      // deno-lint-ignore no-explicit-any
+      () =>
+        parseTrustLineAsset(
+          { switch: () => ({ name: "unknownAssetType" }) } as any,
+        ),
+      Error,
+      "Unsupported trustline asset type",
+    );
+  });
+});

--- a/core/common/helpers/xdr/parse-trustline-asset.unit.test.ts
+++ b/core/common/helpers/xdr/parse-trustline-asset.unit.test.ts
@@ -41,10 +41,11 @@ describe("parseTrustLineAsset", () => {
 
   it("throws for unsupported trustline asset types", () => {
     assertThrows(
-      // deno-lint-ignore no-explicit-any
       () =>
         parseTrustLineAsset(
-          { switch: () => ({ name: "unknownAssetType" }) } as any,
+          {
+            switch: () => ({ name: "unknownAssetType" }),
+          } as unknown as xdr.TrustLineAsset,
         ),
       Error,
       "Unsupported trustline asset type",

--- a/core/common/helpers/xdr/parse-trustline-asset.unit.test.ts
+++ b/core/common/helpers/xdr/parse-trustline-asset.unit.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 import { Asset, Keypair, xdr } from "stellar-sdk";
+import { UNKNOWN_TRUSTLINE_ASSET_TYPE } from "@/common/helpers/xdr/error.ts";
 import { parseTrustLineAsset } from "@/common/helpers/xdr/parse-trustline-asset.ts";
 
 describe("parseTrustLineAsset", () => {
@@ -47,8 +48,8 @@ describe("parseTrustLineAsset", () => {
             switch: () => ({ name: "unknownAssetType" }),
           } as unknown as xdr.TrustLineAsset,
         ),
-      Error,
-      "Unsupported trustline asset type",
+      UNKNOWN_TRUSTLINE_ASSET_TYPE,
+      "Unknown TrustLineAsset type",
     );
   });
 });

--- a/core/event/error.ts
+++ b/core/event/error.ts
@@ -1,0 +1,161 @@
+import { ColibriError } from "@/error/index.ts";
+import type { Diagnostic } from "@/error/types.ts";
+
+export type Meta = {
+  cause: Error | null;
+  data: unknown;
+};
+
+export type EventErrorShape<CodeType extends string> = {
+  code: CodeType;
+  message: string;
+  details: string;
+  diagnostic?: Diagnostic;
+  cause?: Error;
+  data: unknown;
+};
+
+export abstract class EventError<
+  CodeType extends string,
+> extends ColibriError<CodeType, Meta> {
+  override readonly source = "@colibri/core/event";
+  override readonly meta: Meta;
+
+  constructor(args: EventErrorShape<CodeType>) {
+    const meta = {
+      cause: args.cause ?? null,
+      data: args.data,
+    };
+
+    super({
+      domain: "core",
+      source: "@colibri/core/event",
+      code: args.code,
+      message: args.message,
+      details: args.details,
+      diagnostic: args.diagnostic,
+      meta,
+    });
+
+    this.meta = meta;
+  }
+}
+
+export enum Code {
+  INVALID_CONTRACT_ID = "EVT_001",
+  INVALID_EVENT_ID = "EVT_002",
+  UNKNOWN_EVENT_TYPE = "EVT_003",
+  UNKNOWN_FIELD = "EVT_004",
+  EVENT_SCHEMA_MISMATCH = "EVT_005",
+  UNSUPPORTED_SCHEMA_FIELD_TYPE = "EVT_006",
+  INVALID_EVENT_DATA_FORMAT = "EVT_007",
+  INVALID_EVENT_ASSET_FORMAT = "EVT_008",
+}
+
+export class INVALID_CONTRACT_ID extends EventError<Code> {
+  constructor(contractId: string) {
+    super({
+      code: Code.INVALID_CONTRACT_ID,
+      message: `Invalid event: contractId is not a valid ContractId (${contractId})`,
+      details:
+        "The event payload contains a contract id that is not a valid Stellar contract strkey.",
+      data: { contractId },
+    });
+  }
+}
+
+export class INVALID_EVENT_ID extends EventError<Code> {
+  constructor(eventId: string) {
+    super({
+      code: Code.INVALID_EVENT_ID,
+      message: `Invalid event: id is not a valid EventId (${eventId})`,
+      details:
+        "The event payload id does not match Colibri's expected event id shape.",
+      data: { eventId },
+    });
+  }
+}
+
+export class UNKNOWN_EVENT_TYPE extends EventError<Code> {
+  constructor(eventType: string) {
+    super({
+      code: Code.UNKNOWN_EVENT_TYPE,
+      message: `Unknown event type: ${eventType}`,
+      details:
+        "The event payload type is not one of the supported RPC event categories.",
+      data: { eventType },
+    });
+  }
+}
+
+export class UNKNOWN_FIELD extends EventError<Code> {
+  constructor(field: string) {
+    super({
+      code: Code.UNKNOWN_FIELD,
+      message: `Unknown field: ${field}`,
+      details:
+        "The requested field does not exist on the event schema for this template.",
+      data: { field },
+    });
+  }
+}
+
+export class EVENT_SCHEMA_MISMATCH extends EventError<Code> {
+  constructor(schemaName: string, expectedTopicCount: number) {
+    super({
+      code: Code.EVENT_SCHEMA_MISMATCH,
+      message:
+        `Event does not match ${schemaName} schema. Expected ${expectedTopicCount} topics with name "${schemaName}".`,
+      details:
+        "The event topics or value do not match the schema expected by the template class.",
+      data: { schemaName, expectedTopicCount },
+    });
+  }
+}
+
+export class UNSUPPORTED_SCHEMA_FIELD_TYPE extends EventError<Code> {
+  constructor(fieldType: string) {
+    super({
+      code: Code.UNSUPPORTED_SCHEMA_FIELD_TYPE,
+      message: `Cannot convert value to ScVal for type: ${fieldType}`,
+      details:
+        "The event schema references a field type that Colibri cannot convert into ScVal filter segments.",
+      data: { fieldType },
+    });
+  }
+}
+
+export class INVALID_EVENT_DATA_FORMAT extends EventError<Code> {
+  constructor(eventName: string) {
+    super({
+      code: Code.INVALID_EVENT_DATA_FORMAT,
+      message: `Invalid ${eventName} event data format`,
+      details:
+        "The event payload value does not match the format expected by the event accessor.",
+      data: { eventName },
+    });
+  }
+}
+
+export class INVALID_EVENT_ASSET_FORMAT extends EventError<Code> {
+  constructor(asset: string) {
+    super({
+      code: Code.INVALID_EVENT_ASSET_FORMAT,
+      message: `Invalid SEP-11 asset format: ${asset}`,
+      details:
+        "The event topic value is not a valid SEP-11 Stellar asset canonical string.",
+      data: { asset },
+    });
+  }
+}
+
+export const ERROR_EVT = {
+  [Code.INVALID_CONTRACT_ID]: INVALID_CONTRACT_ID,
+  [Code.INVALID_EVENT_ID]: INVALID_EVENT_ID,
+  [Code.UNKNOWN_EVENT_TYPE]: UNKNOWN_EVENT_TYPE,
+  [Code.UNKNOWN_FIELD]: UNKNOWN_FIELD,
+  [Code.EVENT_SCHEMA_MISMATCH]: EVENT_SCHEMA_MISMATCH,
+  [Code.UNSUPPORTED_SCHEMA_FIELD_TYPE]: UNSUPPORTED_SCHEMA_FIELD_TYPE,
+  [Code.INVALID_EVENT_DATA_FORMAT]: INVALID_EVENT_DATA_FORMAT,
+  [Code.INVALID_EVENT_ASSET_FORMAT]: INVALID_EVENT_ASSET_FORMAT,
+};

--- a/core/event/event.ts
+++ b/core/event/event.ts
@@ -11,6 +11,7 @@ import { EventType, type IEvent } from "@/event/types.ts";
 import type { ContractId } from "@/strkeys/types.ts";
 import { isDefined } from "@/common/type-guards/is-defined.ts";
 import { StrKey } from "@/strkeys/index.ts";
+import * as E from "@/event/error.ts";
 
 type EventConstructorArgs = Omit<RpcEventResponseLike, "type" | "contractId"> & {
   type: EventType;
@@ -60,16 +61,15 @@ export class Event implements IEvent {
       const { contractId } = args;
 
       if (!StrKey.isContractId(contractId)) {
-        throw new Error(
-          `Invalid event: contractId is not a valid ContractId (${contractId})`
-        );
+        throw new E.INVALID_CONTRACT_ID(contractId);
       }
 
       this.contractId = contractId;
     }
 
-    if (!isEventId(args.id))
-      throw new Error(`Invalid event: id is not a valid EventId (${args.id})`);
+    if (!isEventId(args.id)) {
+      throw new E.INVALID_EVENT_ID(args.id);
+    }
 
     this.id = args.id;
     this.type = args.type;
@@ -114,7 +114,7 @@ export class Event implements IEvent {
         eventType = EventType.System;
         break;
       default:
-        throw new Error(`Unknown event type: ${response.type}`);
+        throw new E.UNKNOWN_EVENT_TYPE(response.type);
     }
 
     let contractId: ContractId | undefined;
@@ -123,9 +123,7 @@ export class Event implements IEvent {
       const eventContractId = response.contractId?.contractId();
 
       if (!StrKey.isContractId(eventContractId)) {
-        throw new Error(
-          `Invalid event: contractId is not a valid ContractId (${eventContractId})`
-        );
+        throw new E.INVALID_CONTRACT_ID(eventContractId);
       }
 
       contractId = eventContractId;

--- a/core/event/standards/sac/approve.ts
+++ b/core/event/standards/sac/approve.ts
@@ -11,6 +11,7 @@
 
 import { StrKey } from "@/strkeys/index.ts";
 import { EventTemplate } from "@/event/template.ts";
+import * as E from "@/event/error.ts";
 import type { EventSchema } from "@/event/types.ts";
 import { isStellarAssetCanonicalString } from "@/asset/sep11/index.ts";
 import type { StellarAssetCanonicalString } from "@/asset/sep11/types.ts";
@@ -66,7 +67,7 @@ export class ApproveEvent extends EventTemplate<typeof ApproveEventSchema> {
   get asset(): StellarAssetCanonicalString {
     const val = this.get("asset");
     if (!isStellarAssetCanonicalString(val)) {
-      throw new Error(`Invalid SEP-11 asset format: ${val}`);
+      throw new E.INVALID_EVENT_ASSET_FORMAT(val);
     }
     return val;
   }

--- a/core/event/standards/sac/burn.ts
+++ b/core/event/standards/sac/burn.ts
@@ -11,6 +11,7 @@
 
 import { StrKey } from "@/strkeys/index.ts";
 import { EventTemplate } from "@/event/template.ts";
+import * as E from "@/event/error.ts";
 import type { EventSchema } from "@/event/types.ts";
 import { isStellarAssetCanonicalString } from "@/asset/sep11/index.ts";
 import type { StellarAssetCanonicalString } from "@/asset/sep11/types.ts";
@@ -58,7 +59,7 @@ export class BurnEvent extends EventTemplate<typeof BurnEventSchema> {
   get asset(): StellarAssetCanonicalString {
     const val = this.get("asset");
     if (!isStellarAssetCanonicalString(val)) {
-      throw new Error(`Invalid SEP-11 asset format: ${val}`);
+      throw new E.INVALID_EVENT_ASSET_FORMAT(val);
     }
     return val;
   }

--- a/core/event/standards/sac/clawback.ts
+++ b/core/event/standards/sac/clawback.ts
@@ -11,6 +11,7 @@
 
 import { StrKey } from "@/strkeys/index.ts";
 import { EventTemplate } from "@/event/template.ts";
+import * as E from "@/event/error.ts";
 import type { EventSchema } from "@/event/types.ts";
 import { isStellarAssetCanonicalString } from "@/asset/sep11/index.ts";
 import type { StellarAssetCanonicalString } from "@/asset/sep11/types.ts";
@@ -62,7 +63,7 @@ export class ClawbackEvent extends EventTemplate<typeof ClawbackEventSchema> {
   get asset(): StellarAssetCanonicalString {
     const val = this.get("asset");
     if (!isStellarAssetCanonicalString(val)) {
-      throw new Error(`Invalid SEP-11 asset format: ${val}`);
+      throw new E.INVALID_EVENT_ASSET_FORMAT(val);
     }
     return val;
   }

--- a/core/event/standards/sac/mint.ts
+++ b/core/event/standards/sac/mint.ts
@@ -11,6 +11,7 @@
 
 import { StrKey } from "@/strkeys/index.ts";
 import { EventTemplate } from "@/event/template.ts";
+import * as E from "@/event/error.ts";
 import type { EventSchema } from "@/event/types.ts";
 import type { Event } from "@/event/event.ts";
 import { isEventMuxedData } from "@/event/standards/cap67/index.ts";
@@ -98,7 +99,7 @@ export class MintEvent extends EventTemplate<typeof MintEventSchema> {
   get asset(): StellarAssetCanonicalString {
     const val = this.get("asset");
     if (!isStellarAssetCanonicalString(val)) {
-      throw new Error(`Invalid SEP-11 asset format: ${val}`);
+      throw new E.INVALID_EVENT_ASSET_FORMAT(val);
     }
     return val;
   }
@@ -115,7 +116,7 @@ export class MintEvent extends EventTemplate<typeof MintEventSchema> {
     if (isEventMuxedData(val)) {
       return val.amount as bigint;
     }
-    throw new Error("Invalid mint event data format");
+    throw new E.INVALID_EVENT_DATA_FORMAT("mint");
   }
 
   /**

--- a/core/event/standards/sac/set_admin.ts
+++ b/core/event/standards/sac/set_admin.ts
@@ -11,6 +11,7 @@
 
 import { StrKey } from "@/strkeys/index.ts";
 import { EventTemplate } from "@/event/template.ts";
+import * as E from "@/event/error.ts";
 import type { EventSchema } from "@/event/types.ts";
 import { isStellarAssetCanonicalString } from "@/asset/sep11/index.ts";
 import type { StellarAssetCanonicalString } from "@/asset/sep11/types.ts";
@@ -59,7 +60,7 @@ export class SetAdminEvent extends EventTemplate<typeof SetAdminEventSchema> {
   get asset(): StellarAssetCanonicalString {
     const val = this.get("asset");
     if (!isStellarAssetCanonicalString(val)) {
-      throw new Error(`Invalid SEP-11 asset format: ${val}`);
+      throw new E.INVALID_EVENT_ASSET_FORMAT(val);
     }
     return val;
   }

--- a/core/event/standards/sac/set_authorized.ts
+++ b/core/event/standards/sac/set_authorized.ts
@@ -11,6 +11,7 @@
 
 import { StrKey } from "@/strkeys/index.ts";
 import { EventTemplate } from "@/event/template.ts";
+import * as E from "@/event/error.ts";
 import type { EventSchema } from "@/event/types.ts";
 import { isStellarAssetCanonicalString } from "@/asset/sep11/index.ts";
 import type { StellarAssetCanonicalString } from "@/asset/sep11/types.ts";
@@ -65,7 +66,7 @@ export class SetAuthorizedEvent extends EventTemplate<
   get asset(): StellarAssetCanonicalString {
     const val = this.get("asset");
     if (!isStellarAssetCanonicalString(val)) {
-      throw new Error(`Invalid SEP-11 asset format: ${val}`);
+      throw new E.INVALID_EVENT_ASSET_FORMAT(val);
     }
     return val;
   }

--- a/core/event/standards/sac/transfer.ts
+++ b/core/event/standards/sac/transfer.ts
@@ -11,6 +11,7 @@
 
 import { StrKey } from "@/strkeys/index.ts";
 import { EventTemplate } from "@/event/template.ts";
+import * as E from "@/event/error.ts";
 import type { EventSchema } from "@/event/types.ts";
 import type { Event } from "@/event/event.ts";
 import { isEventMuxedData } from "@/event/standards/cap67/index.ts";
@@ -101,7 +102,7 @@ export class TransferEvent extends EventTemplate<typeof TransferEventSchema> {
   get asset(): StellarAssetCanonicalString {
     const val = this.get("asset");
     if (!isStellarAssetCanonicalString(val)) {
-      throw new Error(`Invalid SEP-11 asset format: ${val}`);
+      throw new E.INVALID_EVENT_ASSET_FORMAT(val);
     }
     return val;
   }
@@ -118,7 +119,7 @@ export class TransferEvent extends EventTemplate<typeof TransferEventSchema> {
     if (isEventMuxedData(val)) {
       return val.amount as bigint;
     }
-    throw new Error("Invalid transfer event data format");
+    throw new E.INVALID_EVENT_DATA_FORMAT("transfer");
   }
 
   /**

--- a/core/event/standards/sep41/mint.ts
+++ b/core/event/standards/sep41/mint.ts
@@ -1,5 +1,6 @@
 import { StrKey } from "@/strkeys/index.ts";
 import { EventTemplate } from "@/event/template.ts";
+import * as E from "@/event/error.ts";
 import type { EventSchema } from "@/event/types.ts";
 import type { Event } from "@/event/event.ts";
 import { isEventMuxedData } from "@/event/standards/cap67/index.ts";
@@ -92,7 +93,7 @@ export class MintEvent extends EventTemplate<typeof MintEventSchema> {
     if (isEventMuxedData(val)) {
       return val.amount as bigint;
     }
-    throw new Error("Invalid mint event data format");
+    throw new E.INVALID_EVENT_DATA_FORMAT("mint");
   }
 
   /**

--- a/core/event/standards/sep41/transfer.ts
+++ b/core/event/standards/sep41/transfer.ts
@@ -1,5 +1,6 @@
 import { StrKey } from "@/strkeys/index.ts";
 import { EventTemplate } from "@/event/template.ts";
+import * as E from "@/event/error.ts";
 import type { EventSchema } from "@/event/types.ts";
 import type { Event } from "@/event/event.ts";
 import { isEventMuxedData } from "@/event/standards/cap67/index.ts";
@@ -101,7 +102,7 @@ export class TransferEvent extends EventTemplate<typeof TransferEventSchema> {
     if (isEventMuxedData(val)) {
       return val.amount as bigint;
     }
-    throw new Error("Invalid transfer event data format");
+    throw new E.INVALID_EVENT_DATA_FORMAT("transfer");
   }
 
   /**

--- a/core/event/template.ts
+++ b/core/event/template.ts
@@ -2,6 +2,7 @@ import { Buffer } from "buffer";
 import { Address, xdr } from "stellar-sdk";
 import type { Api } from "stellar-sdk/rpc";
 import { Event } from "@/event/event.ts";
+import * as E from "@/event/error.ts";
 import type {
   EventSchema,
   SchemaFieldType,
@@ -35,7 +36,7 @@ function valueToScVal(value: unknown, type: SchemaFieldType): xdr.ScVal {
       return xdr.ScVal.scvBytes(Buffer.from(value as Uint8Array));
     // For larger integers, we'd need nativeToScVal - keeping simple for now
     default:
-      throw new Error(`Cannot convert value to ScVal for type: ${type}`);
+      throw new E.UNSUPPORTED_SCHEMA_FIELD_TYPE(type);
   }
 }
 
@@ -133,7 +134,7 @@ export abstract class EventTemplate<S extends EventSchema> extends Event {
       return this.topics[topicIndex + 1] as FieldTypeFor<S, K>;
     }
 
-    throw new Error(`Unknown field: ${String(field)}`);
+    throw new E.UNKNOWN_FIELD(String(field));
   }
 
   /**
@@ -178,11 +179,9 @@ export abstract class EventTemplate<S extends EventSchema> extends Event {
   ): T {
     if (!this.is(event)) {
       const schema = this.schema;
-      throw new Error(
-        `Event does not match ${schema.name} schema. ` +
-          `Expected ${schema.topics.length + 1} topics with name "${
-            schema.name
-          }".`
+      throw new E.EVENT_SCHEMA_MISMATCH(
+        schema.name,
+        schema.topics.length + 1,
       );
     }
 
@@ -228,11 +227,9 @@ export abstract class EventTemplate<S extends EventSchema> extends Event {
     const event = Event.fromEventResponse(response);
     if (!this.is(event)) {
       const schema = this.schema;
-      throw new Error(
-        `Event does not match ${schema.name} schema. ` +
-          `Expected ${schema.topics.length + 1} topics with name "${
-            schema.name
-          }".`
+      throw new E.EVENT_SCHEMA_MISMATCH(
+        schema.name,
+        schema.topics.length + 1,
       );
     }
 

--- a/core/ledger-entries/decode.ts
+++ b/core/ledger-entries/decode.ts
@@ -1,0 +1,519 @@
+import { Address, xdr } from "stellar-sdk";
+import { Buffer } from "buffer";
+import { StrKey } from "@/strkeys/index.ts";
+import { parseAccountId } from "@/common/helpers/xdr/parse-account-id.ts";
+import { parseAsset } from "@/common/helpers/xdr/parse-asset.ts";
+import { parseTrustLineAsset } from "@/common/helpers/xdr/parse-trustline-asset.ts";
+import { parseScVal } from "@/common/helpers/xdr/scval.ts";
+import * as E from "@/ledger-entries/error.ts";
+import type { ContractId } from "@/strkeys/types.ts";
+import type { Api } from "stellar-sdk/rpc";
+import type {
+  AccountFlagsView,
+  AccountLedgerEntry,
+  AccountThresholds,
+  AnyLedgerEntry,
+  BaseLedgerEntryOf,
+  ClaimableBalanceFlagsView,
+  ClaimableBalanceLedgerEntry,
+  ClaimPredicateView,
+  ClaimantView,
+  ConfigSettingIdName,
+  ConfigSettingLedgerEntry,
+  ConfigSettingValue,
+  ContractCodeCostInputsView,
+  ContractCodeLedgerEntry,
+  ContractDataDurabilityName,
+  ContractDataLedgerEntry,
+  ContractExecutableView,
+  ContractInstanceLedgerEntry,
+  DataLedgerEntry,
+  LedgerEntryKind,
+  LedgerEntrySigner,
+  LiabilitiesView,
+  LiquidityPoolLedgerEntry,
+  OfferFlagsView,
+  OfferLedgerEntry,
+  OfferPrice,
+  SignerKeyView,
+  TrustlineFlagsView,
+  TrustlineLedgerEntry,
+  TtlLedgerEntry,
+} from "@/ledger-entries/types.ts";
+
+function decodeBaseEntry<TKind extends LedgerEntryKind>(
+  type: TKind,
+  entry: Api.LedgerEntryResult,
+): BaseLedgerEntryOf<TKind> {
+  return {
+    type,
+    xdr: entry,
+    lastModifiedLedgerSeq: entry.lastModifiedLedgerSeq,
+    liveUntilLedgerSeq: entry.liveUntilLedgerSeq,
+  };
+}
+
+function cleanString(value: string | Buffer): string {
+  return (typeof value === "string" ? value : value.toString("utf8"))
+    .replace(/\0/g, "");
+}
+
+function decodeAccountFlags(flags: number): AccountFlagsView {
+  return {
+    value: flags,
+    authRequired: (flags & xdr.AccountFlags.authRequiredFlag().value) !== 0,
+    authRevocable: (flags & xdr.AccountFlags.authRevocableFlag().value) !== 0,
+    authImmutable: (flags & xdr.AccountFlags.authImmutableFlag().value) !== 0,
+    authClawbackEnabled:
+      (flags & xdr.AccountFlags.authClawbackEnabledFlag().value) !== 0,
+  };
+}
+
+function decodeTrustlineFlags(flags: number): TrustlineFlagsView {
+  return {
+    value: flags,
+    authorized: (flags & xdr.TrustLineFlags.authorizedFlag().value) !== 0,
+    authorizedToMaintainLiabilities:
+      (flags &
+        xdr.TrustLineFlags.authorizedToMaintainLiabilitiesFlag().value) !== 0,
+    clawbackEnabled:
+      (flags & xdr.TrustLineFlags.trustlineClawbackEnabledFlag().value) !== 0,
+  };
+}
+
+function decodeOfferFlags(flags: number): OfferFlagsView {
+  return {
+    value: flags,
+    passive: (flags & xdr.OfferEntryFlags.passiveFlag().value) !== 0,
+  };
+}
+
+function decodeClaimableBalanceFlags(flags: number): ClaimableBalanceFlagsView {
+  return {
+    value: flags,
+    clawbackEnabled:
+      (flags & xdr.ClaimableBalanceFlags.claimableBalanceClawbackEnabledFlag()
+        .value) !== 0,
+  };
+}
+
+function decodeLiabilities(liabilities: xdr.Liabilities): LiabilitiesView {
+  return {
+    buying: liabilities.buying().toBigInt(),
+    selling: liabilities.selling().toBigInt(),
+  };
+}
+
+function decodeThresholds(thresholds: Buffer): AccountThresholds {
+  return {
+    masterWeight: thresholds[0] ?? 0,
+    low: thresholds[1] ?? 0,
+    medium: thresholds[2] ?? 0,
+    high: thresholds[3] ?? 0,
+  };
+}
+
+function decodeSignerKey(key: xdr.SignerKey): SignerKeyView {
+  const type = key.switch().name;
+
+  switch (type) {
+    case "signerKeyTypeEd25519":
+      return {
+        type: "ed25519",
+        value: StrKey.encodeEd25519PublicKey(key.ed25519()),
+      };
+
+    case "signerKeyTypePreAuthTx":
+      return {
+        type: "preAuthTx",
+        value: StrKey.encodePreAuthTx(key.preAuthTx()),
+      };
+
+    case "signerKeyTypeHashX":
+      return {
+        type: "hashX",
+        value: StrKey.encodeSha256Hash(key.hashX()),
+      };
+
+    case "signerKeyTypeEd25519SignedPayload": {
+      const signedPayload = key.ed25519SignedPayload();
+      return {
+        type: "ed25519SignedPayload",
+        value: StrKey.encodeSignedPayload(signedPayload.toXDR()),
+        ed25519PublicKey: StrKey.encodeEd25519PublicKey(signedPayload.ed25519()),
+        payload: Uint8Array.from(signedPayload.payload()),
+      };
+    }
+
+    default:
+      throw new Error(`Unsupported signer key type: ${type}`);
+  }
+}
+
+function decodeSigner(signer: xdr.Signer): LedgerEntrySigner {
+  return {
+    key: decodeSignerKey(signer.key()),
+    weight: signer.weight(),
+  };
+}
+
+function decodeClaimPredicate(
+  predicate: xdr.ClaimPredicate,
+): ClaimPredicateView {
+  switch (predicate.switch().name) {
+    case "claimPredicateUnconditional":
+      return { type: "unconditional" };
+    case "claimPredicateAnd":
+      return {
+        type: "and",
+        predicates: predicate.andPredicates().map(decodeClaimPredicate),
+      };
+    case "claimPredicateOr":
+      return {
+        type: "or",
+        predicates: predicate.orPredicates().map(decodeClaimPredicate),
+      };
+    case "claimPredicateNot":
+      return {
+        type: "not",
+        predicate: predicate.notPredicate()
+          ? decodeClaimPredicate(predicate.notPredicate()!)
+          : null,
+      };
+    case "claimPredicateBeforeAbsoluteTime":
+      return {
+        type: "beforeAbsoluteTime",
+        unixSeconds: predicate.absBefore().toBigInt(),
+      };
+    case "claimPredicateBeforeRelativeTime":
+      return {
+        type: "beforeRelativeTime",
+        seconds: predicate.relBefore().toBigInt(),
+      };
+    default:
+      throw new Error(`Unsupported claim predicate type: ${predicate.switch().name}`);
+  }
+}
+
+function decodeClaimant(claimant: xdr.Claimant): ClaimantView {
+  const v0 = claimant.v0();
+  return {
+    destination: parseAccountId(v0.destination()),
+    predicate: decodeClaimPredicate(v0.predicate()),
+  };
+}
+
+function decodeContractExecutable(
+  executable: xdr.ContractExecutable,
+): ContractExecutableView {
+  switch (executable.switch().name) {
+    case "contractExecutableWasm":
+      return {
+        type: "wasm",
+        wasmHash: executable.wasmHash().toString("hex"),
+      };
+    case "contractExecutableStellarAsset":
+      return {
+        type: "stellarAsset",
+      };
+    default:
+      throw new Error(
+        `Unsupported contract executable type: ${executable.switch().name}`,
+      );
+  }
+}
+
+function normalizeConfigSettingValue(value: ConfigSettingValue): ConfigSettingValue {
+  if (Array.isArray(value) && value.every((item) =>
+    typeof item === "object" && item !== null && "toBigInt" in item
+  )) {
+    return value.map((item) => item.toBigInt()) as bigint[];
+  }
+
+  return value;
+}
+
+function decodeContractCodeCostInputs(
+  costInputs: xdr.ContractCodeCostInputs,
+): ContractCodeCostInputsView {
+  return {
+    nInstructions: costInputs.nInstructions(),
+    nFunctions: costInputs.nFunctions(),
+    nGlobals: costInputs.nGlobals(),
+    nTableEntries: costInputs.nTableEntries(),
+    nTypes: costInputs.nTypes(),
+    nDataSegments: costInputs.nDataSegments(),
+    nElemSegments: costInputs.nElemSegments(),
+    nImports: costInputs.nImports(),
+    nExports: costInputs.nExports(),
+    nDataSegmentBytes: costInputs.nDataSegmentBytes(),
+  };
+}
+
+function decodeAccountEntry(entry: Api.LedgerEntryResult): AccountLedgerEntry {
+  const account = entry.val.account();
+
+  return {
+    ...decodeBaseEntry("account", entry),
+    accountId: parseAccountId(account.accountId()),
+    balance: account.balance().toBigInt(),
+    sequenceNumber: account.seqNum().toBigInt(),
+    numSubEntries: account.numSubEntries(),
+    inflationDestination: account.inflationDest()
+      ? parseAccountId(account.inflationDest()!)
+      : undefined,
+    flags: decodeAccountFlags(account.flags()),
+    homeDomain: cleanString(account.homeDomain()),
+    thresholds: decodeThresholds(Buffer.from(account.thresholds())),
+    signers: account.signers().map(decodeSigner),
+  };
+}
+
+function decodeTrustlineEntry(
+  entry: Api.LedgerEntryResult,
+): TrustlineLedgerEntry {
+  const trustline = entry.val.trustLine();
+
+  return {
+    ...decodeBaseEntry("trustline", entry),
+    accountId: parseAccountId(trustline.accountId()),
+    asset: parseTrustLineAsset(trustline.asset()),
+    balance: trustline.balance().toBigInt(),
+    limit: trustline.limit().toBigInt(),
+    flags: decodeTrustlineFlags(trustline.flags()),
+    liabilities: trustline.ext().switch() === 1
+      ? decodeLiabilities(trustline.ext().v1().liabilities())
+      : undefined,
+  };
+}
+
+function decodeOfferEntry(entry: Api.LedgerEntryResult): OfferLedgerEntry {
+  const offer = entry.val.offer();
+  const price: OfferPrice = {
+    n: offer.price().n(),
+    d: offer.price().d(),
+  };
+
+  return {
+    ...decodeBaseEntry("offer", entry),
+    sellerId: parseAccountId(offer.sellerId()),
+    offerId: offer.offerId().toBigInt(),
+    selling: parseAsset(offer.selling()),
+    buying: parseAsset(offer.buying()),
+    amount: offer.amount().toBigInt(),
+    price,
+    flags: decodeOfferFlags(offer.flags()),
+  };
+}
+
+function decodeDataEntry(entry: Api.LedgerEntryResult): DataLedgerEntry {
+  const data = entry.val.data();
+
+  return {
+    ...decodeBaseEntry("data", entry),
+    accountId: parseAccountId(data.accountId()),
+    dataName: cleanString(data.dataName()),
+    dataValue: Uint8Array.from(data.dataValue()),
+  };
+}
+
+function decodeClaimableBalanceEntry(
+  entry: Api.LedgerEntryResult,
+): ClaimableBalanceLedgerEntry {
+  const claimableBalance = entry.val.claimableBalance();
+  const flags = claimableBalance.ext().switch() === 1
+    ? claimableBalance.ext().v1().flags()
+    : 0;
+
+  return {
+    ...decodeBaseEntry("claimableBalance", entry),
+    balanceId: StrKey.encodeClaimableBalance(
+      Buffer.concat([
+        Buffer.from([0]),
+        Buffer.from(claimableBalance.balanceId().v0()),
+      ]),
+    ),
+    claimants: claimableBalance.claimants().map(decodeClaimant),
+    asset: parseAsset(claimableBalance.asset()),
+    amount: claimableBalance.amount().toBigInt(),
+    flags: decodeClaimableBalanceFlags(flags),
+  };
+}
+
+function decodeLiquidityPoolEntry(
+  entry: Api.LedgerEntryResult,
+): LiquidityPoolLedgerEntry {
+  const liquidityPool = entry.val.liquidityPool();
+  const constantProduct = liquidityPool.body().constantProduct();
+  const params = constantProduct.params();
+
+  return {
+    ...decodeBaseEntry("liquidityPool", entry),
+    liquidityPoolId: StrKey.encodeLiquidityPool(
+      Buffer.from(liquidityPool.liquidityPoolId() as unknown as Uint8Array),
+    ),
+    poolType: "liquidityPoolConstantProduct",
+    assetA: parseAsset(params.assetA()),
+    assetB: parseAsset(params.assetB()),
+    fee: params.fee(),
+    reserveA: constantProduct.reserveA().toBigInt(),
+    reserveB: constantProduct.reserveB().toBigInt(),
+    totalPoolShares: constantProduct.totalPoolShares().toBigInt(),
+    poolSharesTrustLineCount: constantProduct.poolSharesTrustLineCount()
+      .toBigInt(),
+  };
+}
+
+function decodeContractDataEntry(
+  entry: Api.LedgerEntryResult,
+): ContractDataLedgerEntry {
+  const contractData = entry.val.contractData();
+
+  return {
+    ...decodeBaseEntry("contractData", entry),
+    contractId: Address.fromScAddress(contractData.contract()).toString() as ContractId,
+    durability: contractData.durability().name as ContractDataDurabilityName,
+    keyScVal: contractData.key(),
+    valueScVal: contractData.val(),
+    key: parseScVal(contractData.key()),
+    value: parseScVal(contractData.val()),
+  };
+}
+
+function decodeContractInstanceEntry(
+  entry: Api.LedgerEntryResult,
+): ContractInstanceLedgerEntry {
+  const contractData = entry.val.contractData();
+  const instance = contractData.val().instance();
+  const storage = xdr.ScVal.scvMap(instance.storage() ?? []);
+
+  return {
+    ...decodeBaseEntry("contractInstance", entry),
+    contractId: Address.fromScAddress(contractData.contract()).toString() as ContractId,
+    durability: contractData.durability().name as ContractDataDurabilityName,
+    keyScVal: contractData.key(),
+    valueScVal: contractData.val(),
+    executable: decodeContractExecutable(instance.executable()),
+    storage: parseScVal(storage),
+  };
+}
+
+function decodeContractCodeEntry(
+  entry: Api.LedgerEntryResult,
+): ContractCodeLedgerEntry {
+  const contractCode = entry.val.contractCode();
+
+  return {
+    ...decodeBaseEntry("contractCode", entry),
+    hash: contractCode.hash().toString("hex"),
+    code: Uint8Array.from(contractCode.code()),
+    costInputs: contractCode.ext().switch() === 1
+      ? decodeContractCodeCostInputs(contractCode.ext().v1().costInputs())
+      : undefined,
+  };
+}
+
+function decodeConfigSettingEntry(
+  entry: Api.LedgerEntryResult,
+): ConfigSettingLedgerEntry {
+  const configSetting = entry.val.configSetting();
+
+  return {
+    ...decodeBaseEntry("configSetting", entry),
+    configSettingId: configSetting.switch().name as ConfigSettingIdName,
+    value: normalizeConfigSettingValue(configSetting.value()),
+  };
+}
+
+function decodeTtlEntry(entry: Api.LedgerEntryResult): TtlLedgerEntry {
+  const ttl = entry.val.ttl();
+
+  return {
+    ...decodeBaseEntry("ttl", entry),
+    keyHash: StrKey.encodeSha256Hash(ttl.keyHash()),
+    expiresAtLedger: ttl.liveUntilLedgerSeq(),
+  };
+}
+
+/**
+ * Derives the logical entry type represented by a ledger key.
+ */
+export function detectLedgerEntryKindFromKey(key: xdr.LedgerKey): LedgerEntryKind {
+  switch (key.switch().name) {
+    case "account":
+      return "account";
+    case "trustline":
+      return "trustline";
+    case "offer":
+      return "offer";
+    case "data":
+      return "data";
+    case "claimableBalance":
+      return "claimableBalance";
+    case "liquidityPool":
+      return "liquidityPool";
+    case "contractData":
+      return key.contractData().key().switch().name ===
+          "scvLedgerKeyContractInstance"
+        ? "contractInstance"
+        : "contractData";
+    case "contractCode":
+      return "contractCode";
+    case "configSetting":
+      return "configSetting";
+    case "ttl":
+      return "ttl";
+    default:
+      throw new Error(`Unsupported ledger key type: ${key.switch().name}`);
+  }
+}
+
+/**
+ * Decodes a parsed RPC ledger-entry result into the corresponding friendly shape.
+ */
+export function decodeLedgerEntry(entry: Api.LedgerEntryResult): AnyLedgerEntry {
+  switch (entry.val.switch().name) {
+    case "account":
+      return decodeAccountEntry(entry);
+    case "trustline":
+      return decodeTrustlineEntry(entry);
+    case "offer":
+      return decodeOfferEntry(entry);
+    case "data":
+      return decodeDataEntry(entry);
+    case "claimableBalance":
+      return decodeClaimableBalanceEntry(entry);
+    case "liquidityPool":
+      return decodeLiquidityPoolEntry(entry);
+    case "contractData":
+      return entry.val.contractData().key().switch().name ===
+          "scvLedgerKeyContractInstance"
+        ? decodeContractInstanceEntry(entry)
+        : decodeContractDataEntry(entry);
+    case "contractCode":
+      return decodeContractCodeEntry(entry);
+    case "configSetting":
+      return decodeConfigSettingEntry(entry);
+    case "ttl":
+      return decodeTtlEntry(entry);
+    default:
+      throw new Error(`Unsupported ledger entry type: ${entry.val.switch().name}`);
+  }
+}
+
+/**
+ * Decodes and validates that the RPC result matches the requested key type.
+ */
+export function decodeLedgerEntryForKey(
+  key: xdr.LedgerKey,
+  entry: Api.LedgerEntryResult,
+): AnyLedgerEntry {
+  const expected = detectLedgerEntryKindFromKey(key);
+  const decoded = decodeLedgerEntry(entry);
+
+  if (decoded.type !== expected) {
+    throw new E.UNEXPECTED_LEDGER_ENTRY_TYPE(expected, decoded.type);
+  }
+
+  return decoded;
+}

--- a/core/ledger-entries/decode.ts
+++ b/core/ledger-entries/decode.ts
@@ -223,11 +223,22 @@ function decodeContractExecutable(
   }
 }
 
+function isBigIntLike(value: unknown): value is { toBigInt(): bigint } {
+  return typeof value === "object" &&
+    value !== null &&
+    "toBigInt" in value &&
+    typeof (value as { toBigInt?: unknown }).toBigInt === "function";
+}
+
+function isBigIntLikeArray(
+  value: ConfigSettingValue,
+): value is readonly { toBigInt(): bigint }[] {
+  return Array.isArray(value) && value.every(isBigIntLike);
+}
+
 function normalizeConfigSettingValue(value: ConfigSettingValue): ConfigSettingValue {
-  if (Array.isArray(value) && value.every((item) =>
-    typeof item === "object" && item !== null && "toBigInt" in item
-  )) {
-    return value.map((item) => item.toBigInt()) as bigint[];
+  if (isBigIntLikeArray(value)) {
+    return value.map((item) => item.toBigInt());
   }
 
   return value;

--- a/core/ledger-entries/decode.ts
+++ b/core/ledger-entries/decode.ts
@@ -146,7 +146,7 @@ function decodeSignerKey(key: xdr.SignerKey): SignerKeyView {
     }
 
     default:
-      throw new Error(`Unsupported signer key type: ${type}`);
+      throw new E.UNSUPPORTED_XDR_VARIANT("signer key", type);
   }
 }
 
@@ -191,7 +191,10 @@ function decodeClaimPredicate(
         seconds: predicate.relBefore().toBigInt(),
       };
     default:
-      throw new Error(`Unsupported claim predicate type: ${predicate.switch().name}`);
+      throw new E.UNSUPPORTED_XDR_VARIANT(
+        "claim predicate",
+        predicate.switch().name,
+      );
   }
 }
 
@@ -217,8 +220,9 @@ function decodeContractExecutable(
         type: "stellarAsset",
       };
     default:
-      throw new Error(
-        `Unsupported contract executable type: ${executable.switch().name}`,
+      throw new E.UNSUPPORTED_XDR_VARIANT(
+        "contract executable",
+        executable.switch().name,
       );
   }
 }
@@ -475,7 +479,7 @@ export function detectLedgerEntryKindFromKey(key: xdr.LedgerKey): LedgerEntryKin
     case "ttl":
       return "ttl";
     default:
-      throw new Error(`Unsupported ledger key type: ${key.switch().name}`);
+      throw new E.UNSUPPORTED_XDR_VARIANT("ledger key", key.switch().name);
   }
 }
 
@@ -508,7 +512,10 @@ export function decodeLedgerEntry(entry: Api.LedgerEntryResult): AnyLedgerEntry 
     case "ttl":
       return decodeTtlEntry(entry);
     default:
-      throw new Error(`Unsupported ledger entry type: ${entry.val.switch().name}`);
+      throw new E.UNSUPPORTED_XDR_VARIANT(
+        "ledger entry",
+        entry.val.switch().name,
+      );
   }
 }
 

--- a/core/ledger-entries/decode.unit.test.ts
+++ b/core/ledger-entries/decode.unit.test.ts
@@ -1,0 +1,426 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { Buffer } from "buffer";
+import { Address, Asset, Keypair, xdr } from "stellar-sdk";
+import type { Api } from "stellar-sdk/rpc";
+import { parseTrustLineAsset } from "@/common/helpers/xdr/parse-trustline-asset.ts";
+import {
+  decodeLedgerEntry,
+  decodeLedgerEntryForKey,
+  detectLedgerEntryKindFromKey,
+} from "@/ledger-entries/decode.ts";
+import * as E from "@/ledger-entries/error.ts";
+import {
+  buildAccountLedgerKey,
+  buildClaimableBalanceLedgerKey,
+  buildConfigSettingLedgerKey,
+  buildContractCodeLedgerKey,
+  buildContractInstanceLedgerKey,
+  buildTrustlineLedgerKey,
+} from "@/ledger-entries/index.ts";
+import { StrKey } from "@/strkeys/index.ts";
+import type {
+  ClaimableBalanceId,
+  ContractId,
+  Ed25519PublicKey,
+} from "@/strkeys/types.ts";
+
+const ACCOUNT_ID = Keypair.random().publicKey() as Ed25519PublicKey;
+const SECOND_ACCOUNT_ID = Keypair.random().publicKey() as Ed25519PublicKey;
+const CONTRACT_ID = StrKey.encodeContract(Buffer.alloc(32, 3)) as ContractId;
+const CLAIMABLE_BALANCE_ID =
+  "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU" as ClaimableBalanceId;
+
+function makeResult(
+  key: xdr.LedgerKey,
+  val: xdr.LedgerEntryData,
+  extras: Partial<Api.LedgerEntryResult> = {},
+): Api.LedgerEntryResult {
+  return {
+    key,
+    val,
+    ...extras,
+  };
+}
+
+function makeMockEntry(
+  entryType: string,
+  arm: string,
+  payload: unknown,
+  key = buildAccountLedgerKey({
+    accountId: ACCOUNT_ID,
+  }) as unknown as xdr.LedgerKey,
+): Api.LedgerEntryResult {
+  return {
+    key,
+    val: {
+      switch: () => ({ name: entryType, value: 0 }),
+      [arm]: () => payload,
+    } as unknown as xdr.LedgerEntryData,
+  };
+}
+
+describe("LedgerEntries decode helpers", () => {
+  it("covers additional signer-key variants and account fallbacks", () => {
+    const rawPublicKey = Keypair.fromPublicKey(ACCOUNT_ID).rawPublicKey();
+    const signedPayload = new xdr.SignerKeyEd25519SignedPayload({
+      ed25519: rawPublicKey,
+      payload: Buffer.from([1, 2, 3]),
+    });
+
+    const entry = makeMockEntry("account", "account", {
+      accountId: () => Keypair.fromPublicKey(ACCOUNT_ID).xdrAccountId(),
+      balance: () => xdr.Int64.fromString("50"),
+      seqNum: () => xdr.Int64.fromString("9"),
+      numSubEntries: () => 4,
+      inflationDest: () => undefined,
+      flags: () => 0,
+      homeDomain: () => Buffer.from(""),
+      thresholds: () => Buffer.from([]),
+      signers: () => [
+        {
+          key: () => xdr.SignerKey.signerKeyTypeEd25519(rawPublicKey),
+          weight: () => 1,
+        },
+        {
+          key: () =>
+            xdr.SignerKey.signerKeyTypePreAuthTx(
+              Buffer.alloc(32, 4),
+            ),
+          weight: () => 2,
+        },
+        {
+          key: () => xdr.SignerKey.signerKeyTypeHashX(Buffer.alloc(32, 5)),
+          weight: () => 3,
+        },
+        {
+          key: () =>
+            xdr.SignerKey.signerKeyTypeEd25519SignedPayload(signedPayload),
+          weight: () => 4,
+        },
+      ],
+    });
+
+    const decoded = decodeLedgerEntry(entry);
+
+    assertEquals(decoded.type, "account");
+    if (decoded.type !== "account") {
+      throw new Error("expected account entry");
+    }
+    assertEquals(decoded.inflationDestination, undefined);
+    assertEquals(decoded.thresholds.high, 0);
+    assertEquals(decoded.signers[1].key.type, "preAuthTx");
+    assertEquals(decoded.signers[2].key.type, "hashX");
+    assertEquals(decoded.signers[3].key.type, "ed25519SignedPayload");
+  });
+
+  it("covers additional claim-predicate variants", () => {
+    const destination = Keypair.fromPublicKey(SECOND_ACCOUNT_ID)
+      .xdrAccountId();
+    const claimants = [
+      xdr.Claimant.claimantTypeV0(
+        new xdr.ClaimantV0({
+          destination,
+          predicate: xdr.ClaimPredicate.claimPredicateUnconditional(),
+        }),
+      ),
+      xdr.Claimant.claimantTypeV0(
+        new xdr.ClaimantV0({
+          destination,
+          predicate: xdr.ClaimPredicate.claimPredicateAnd([
+            xdr.ClaimPredicate.claimPredicateUnconditional(),
+            xdr.ClaimPredicate.claimPredicateBeforeAbsoluteTime(
+              xdr.Int64.fromString("123"),
+            ),
+          ]),
+        }),
+      ),
+      xdr.Claimant.claimantTypeV0(
+        new xdr.ClaimantV0({
+          destination,
+          predicate: xdr.ClaimPredicate.claimPredicateOr([
+            xdr.ClaimPredicate.claimPredicateUnconditional(),
+            xdr.ClaimPredicate.claimPredicateBeforeAbsoluteTime(
+              xdr.Int64.fromString("456"),
+            ),
+          ]),
+        }),
+      ),
+      xdr.Claimant.claimantTypeV0(
+        new xdr.ClaimantV0({
+          destination,
+          predicate: xdr.ClaimPredicate.claimPredicateNot(
+            xdr.ClaimPredicate.claimPredicateBeforeAbsoluteTime(
+              xdr.Int64.fromString("789"),
+            ),
+          ),
+        }),
+      ),
+    ];
+    const key = buildClaimableBalanceLedgerKey({
+      balanceId: CLAIMABLE_BALANCE_ID,
+    }) as unknown as xdr.LedgerKey;
+    const balanceId = xdr.ClaimableBalanceId.claimableBalanceIdTypeV0(
+      Buffer.from(StrKey.decodeClaimableBalance(CLAIMABLE_BALANCE_ID))
+        .subarray(1),
+    );
+    const entry = makeResult(
+      key,
+      xdr.LedgerEntryData.claimableBalance(
+        new xdr.ClaimableBalanceEntry({
+          balanceId,
+          claimants,
+          asset: Asset.native().toXDRObject(),
+          amount: xdr.Int64.fromString("99"),
+          ext: new xdr.ClaimableBalanceEntryExt(0),
+        }),
+      ),
+    );
+
+    const decoded = decodeLedgerEntry(entry);
+
+    assertEquals(decoded.type, "claimableBalance");
+    if (decoded.type !== "claimableBalance") {
+      throw new Error("expected claimable balance entry");
+    }
+    assertEquals(decoded.flags.clawbackEnabled, false);
+    assertEquals(decoded.claimants[0].predicate.type, "unconditional");
+    assertEquals(decoded.claimants[1].predicate.type, "and");
+    assertEquals(decoded.claimants[2].predicate.type, "or");
+    assertEquals(decoded.claimants[3].predicate.type, "not");
+  });
+
+  it("covers nullable claim predicates", () => {
+    const decoded = decodeLedgerEntry(
+      makeMockEntry("claimableBalance", "claimableBalance", {
+        balanceId: () => ({
+          v0: () => new Uint8Array(32).fill(1),
+        }),
+        claimants: () => [{
+          v0: () => ({
+            destination: () =>
+              Keypair.fromPublicKey(ACCOUNT_ID).xdrAccountId(),
+            predicate: () => ({
+              switch: () => ({ name: "claimPredicateNot" }),
+              notPredicate: () => null,
+            }),
+          }),
+        }],
+        asset: () => Asset.native().toXDRObject(),
+        amount: () => xdr.Int64.fromString("1"),
+        ext: () => ({ switch: () => 0 }),
+      }),
+    );
+
+    assertEquals(decoded.type, "claimableBalance");
+    if (decoded.type !== "claimableBalance") {
+      throw new Error("expected claimable balance entry");
+    }
+    assertEquals(decoded.claimants[0].predicate.type, "not");
+    if (decoded.claimants[0].predicate.type !== "not") {
+      throw new Error("expected not predicate");
+    }
+    assertEquals(decoded.claimants[0].predicate.predicate, null);
+  });
+
+  it("covers trustline, contract code, contract instance, and config fallbacks", () => {
+    const trustlineKey = buildTrustlineLedgerKey({
+      accountId: ACCOUNT_ID,
+      asset: Asset.native(),
+    }) as unknown as xdr.LedgerKey;
+    const trustlineEntry = makeResult(
+      trustlineKey,
+      xdr.LedgerEntryData.trustline(
+        new xdr.TrustLineEntry({
+          accountId: Keypair.fromPublicKey(ACCOUNT_ID).xdrAccountId(),
+          asset: Asset.native().toTrustLineXDRObject() as xdr.TrustLineAsset,
+          balance: xdr.Int64.fromString("5"),
+          limit: xdr.Int64.fromString("10"),
+          flags: 0,
+          ext: new xdr.TrustLineEntryExt(0),
+        }),
+      ),
+    );
+    const codeEntry = makeResult(
+      buildContractCodeLedgerKey({
+        hash: "cd".repeat(32),
+      }) as unknown as xdr.LedgerKey,
+      xdr.LedgerEntryData.contractCode(
+        new xdr.ContractCodeEntry({
+          hash: Buffer.from("cd".repeat(32), "hex"),
+          code: Buffer.from([9, 8, 7]),
+          ext: new xdr.ContractCodeEntryExt(0),
+        }),
+      ),
+    );
+    const instanceEntry = makeMockEntry(
+      "contractData",
+      "contractData",
+      {
+        contract: () => Address.fromString(CONTRACT_ID).toScAddress(),
+        durability: () => xdr.ContractDataDurability.persistent(),
+        key: () => xdr.ScVal.scvLedgerKeyContractInstance(),
+        val: () => ({
+          instance: () => ({
+            executable: () =>
+              xdr.ContractExecutable.contractExecutableStellarAsset(),
+            storage: () => undefined,
+          }),
+        }),
+      },
+      buildContractInstanceLedgerKey({
+        contractId: CONTRACT_ID,
+      }) as unknown as xdr.LedgerKey,
+    );
+    const configEntry = makeMockEntry(
+      "configSetting",
+      "configSetting",
+      {
+        switch: () => ({ name: "configSettingStateArchival", value: 0 }),
+        value: () => [
+          { toBigInt: () => 1n },
+          { toBigInt: () => 2n },
+        ],
+      },
+      buildConfigSettingLedgerKey({
+        configSettingId: "configSettingStateArchival",
+      }) as unknown as xdr.LedgerKey,
+    );
+
+    const decodedTrustline = decodeLedgerEntry(trustlineEntry);
+    const decodedCode = decodeLedgerEntry(codeEntry);
+    const decodedInstance = decodeLedgerEntry(instanceEntry);
+    const decodedConfig = decodeLedgerEntry(configEntry);
+
+    assertEquals(decodedTrustline.type, "trustline");
+    if (decodedTrustline.type !== "trustline") {
+      throw new Error("expected trustline entry");
+    }
+    assertEquals(
+      decodedTrustline.asset,
+      parseTrustLineAsset(
+        Asset.native().toTrustLineXDRObject() as xdr.TrustLineAsset,
+      ),
+    );
+    assertEquals(decodedTrustline.liabilities, undefined);
+    assertEquals(decodedCode.type, "contractCode");
+    if (decodedCode.type !== "contractCode") {
+      throw new Error("expected contract code entry");
+    }
+    assertEquals(decodedCode.costInputs, undefined);
+    assertEquals(decodedInstance.type, "contractInstance");
+    if (decodedInstance.type !== "contractInstance") {
+      throw new Error("expected contract instance entry");
+    }
+    assertEquals(decodedInstance.executable.type, "stellarAsset");
+    assertEquals(decodedConfig.type, "configSetting");
+    if (decodedConfig.type !== "configSetting") {
+      throw new Error("expected config setting entry");
+    }
+    assertEquals(decodedConfig.value, [1n, 2n]);
+  });
+
+  it("covers unsupported decode branches", () => {
+    assertThrows(
+      () =>
+        decodeLedgerEntry(
+          makeMockEntry("account", "account", {
+            accountId: () => Keypair.fromPublicKey(ACCOUNT_ID).xdrAccountId(),
+            balance: () => xdr.Int64.fromString("1"),
+            seqNum: () => xdr.Int64.fromString("1"),
+            numSubEntries: () => 1,
+            inflationDest: () => undefined,
+            flags: () => 0,
+            homeDomain: () => "",
+            thresholds: () => Buffer.from([0, 0, 0, 0]),
+            signers: () => [
+              {
+                key: () => ({
+                  switch: () => ({ name: "unsupportedSignerKey" }),
+                }),
+                weight: () => 1,
+              },
+            ],
+          }),
+        ),
+      Error,
+      "Unsupported signer key type",
+    );
+    assertThrows(
+      () =>
+        decodeLedgerEntry(
+          makeMockEntry("claimableBalance", "claimableBalance", {
+            balanceId: () => ({
+              v0: () => new Uint8Array(32).fill(1),
+            }),
+            claimants: () => [{
+              v0: () => ({
+                destination: () =>
+                  Keypair.fromPublicKey(ACCOUNT_ID).xdrAccountId(),
+                predicate: () => ({
+                  switch: () => ({ name: "unsupportedPredicate" }),
+                }),
+              }),
+            }],
+            asset: () => Asset.native().toXDRObject(),
+            amount: () => xdr.Int64.fromString("1"),
+            ext: () => ({ switch: () => 0 }),
+          }),
+        ),
+      Error,
+      "Unsupported claim predicate type",
+    );
+    assertThrows(
+      () =>
+        decodeLedgerEntry(
+          makeMockEntry("contractData", "contractData", {
+            contract: () => Address.fromString(CONTRACT_ID).toScAddress(),
+            durability: () => xdr.ContractDataDurability.persistent(),
+            key: () => xdr.ScVal.scvLedgerKeyContractInstance(),
+            val: () => ({
+              instance: () => ({
+                executable: () => ({
+                  switch: () => ({ name: "unsupportedExecutable" }),
+                }),
+                storage: () => [],
+              }),
+            }),
+          }),
+        ),
+      Error,
+      "Unsupported contract executable type",
+    );
+    assertThrows(
+      () =>
+        detectLedgerEntryKindFromKey({
+          switch: () => ({ name: "unsupportedKeyType" }),
+        } as unknown as xdr.LedgerKey),
+      Error,
+      "Unsupported ledger key type",
+    );
+    assertThrows(
+      () =>
+        decodeLedgerEntry({
+          val: {
+            switch: () => ({ name: "unsupportedEntryType" }),
+          },
+        } as unknown as Api.LedgerEntryResult),
+      Error,
+      "Unsupported ledger entry type",
+    );
+    assertThrows(
+      () =>
+        decodeLedgerEntryForKey(
+          buildAccountLedgerKey({
+            accountId: ACCOUNT_ID,
+          }) as unknown as xdr.LedgerKey,
+          makeMockEntry("data", "data", {
+            accountId: () => Keypair.fromPublicKey(ACCOUNT_ID).xdrAccountId(),
+            dataName: () => "profile",
+            dataValue: () => new Uint8Array([1]),
+          }),
+        ),
+      E.UNEXPECTED_LEDGER_ENTRY_TYPE,
+    );
+  });
+});

--- a/core/ledger-entries/decode.unit.test.ts
+++ b/core/ledger-entries/decode.unit.test.ts
@@ -16,6 +16,7 @@ import {
   buildConfigSettingLedgerKey,
   buildContractCodeLedgerKey,
   buildContractInstanceLedgerKey,
+  buildTtlLedgerKey,
   buildTrustlineLedgerKey,
 } from "@/ledger-entries/index.ts";
 import { StrKey } from "@/strkeys/index.ts";
@@ -156,6 +157,14 @@ describe("LedgerEntries decode helpers", () => {
           ),
         }),
       ),
+      xdr.Claimant.claimantTypeV0(
+        new xdr.ClaimantV0({
+          destination,
+          predicate: xdr.ClaimPredicate.claimPredicateBeforeRelativeTime(
+            xdr.Int64.fromString("321"),
+          ),
+        }),
+      ),
     ];
     const key = buildClaimableBalanceLedgerKey({
       balanceId: CLAIMABLE_BALANCE_ID,
@@ -188,6 +197,7 @@ describe("LedgerEntries decode helpers", () => {
     assertEquals(decoded.claimants[1].predicate.type, "and");
     assertEquals(decoded.claimants[2].predicate.type, "or");
     assertEquals(decoded.claimants[3].predicate.type, "not");
+    assertEquals(decoded.claimants[4].predicate.type, "beforeRelativeTime");
   });
 
   it("covers nullable claim predicates", () => {
@@ -318,6 +328,14 @@ describe("LedgerEntries decode helpers", () => {
       throw new Error("expected config setting entry");
     }
     assertEquals(decodedConfig.value, [1n, 2n]);
+  });
+
+  it("covers ttl key detection", () => {
+    const ttlKey = buildTtlLedgerKey({
+      keyHash: StrKey.encodeSha256Hash(Buffer.alloc(32, 9)),
+    }) as unknown as xdr.LedgerKey;
+
+    assertEquals(detectLedgerEntryKindFromKey(ttlKey), "ttl");
   });
 
   it("covers unsupported decode branches", () => {

--- a/core/ledger-entries/error.ts
+++ b/core/ledger-entries/error.ts
@@ -1,0 +1,339 @@
+import { ColibriError } from "@/error/index.ts";
+import type { Diagnostic } from "@/error/types.ts";
+import type { LedgerEntryKind } from "@/ledger-entries/types.ts";
+
+/**
+ * Metadata stored on ledger-entries errors.
+ */
+export type Meta = {
+  cause: Error | null;
+  data: unknown;
+};
+
+/**
+ * Shape accepted by {@link LedgerEntriesError} constructors.
+ */
+export type LedgerEntriesErrorShape<Code extends string> = {
+  code: Code;
+  message: string;
+  details: string;
+  diagnostic?: Diagnostic;
+  cause?: Error;
+  data: unknown;
+};
+
+/**
+ * Base class for ledger-entries-module errors.
+ */
+export abstract class LedgerEntriesError<
+  Code extends string,
+> extends ColibriError<Code, Meta> {
+  /** Structured metadata preserved on ledger-entries errors. */
+  override readonly meta: Meta;
+
+  /**
+   * Creates a new ledger-entries error.
+   *
+   * @param args - Error construction payload.
+   */
+  constructor(args: LedgerEntriesErrorShape<Code>) {
+    const meta = {
+      cause: args.cause || null,
+      data: args.data,
+    };
+
+    super({
+      domain: "core" as const,
+      source: "@colibri/core/ledger-entries",
+      code: args.code,
+      message: args.message,
+      details: args.details,
+      diagnostic: args.diagnostic,
+      meta,
+    });
+
+    this.meta = meta;
+  }
+}
+
+/**
+ * Stable error codes emitted by the ledger-entries module.
+ */
+export enum Code {
+  INVALID_CONSTRUCTOR_ARGS = "LDE_000",
+  MISSING_RPC_URL = "LDE_001",
+  INVALID_ACCOUNT_ID = "LDE_002",
+  INVALID_CONTRACT_ID = "LDE_003",
+  INVALID_CLAIMABLE_BALANCE_ID = "LDE_004",
+  INVALID_LIQUIDITY_POOL_ID = "LDE_005",
+  INVALID_HEX_HASH = "LDE_006",
+  INVALID_CONFIG_SETTING_ID = "LDE_007",
+  INVALID_LEDGER_KEY_HASH = "LDE_008",
+  LEDGER_ENTRY_NOT_FOUND = "LDE_009",
+  UNEXPECTED_LEDGER_ENTRY_TYPE = "LDE_010",
+  CONTRACT_INSTANCE_HAS_NO_WASM_HASH = "LDE_011",
+  UNSUPPORTED_RPC_LEDGER_KEY = "LDE_012",
+}
+
+/**
+ * Raised when the constructor receives both or neither supported init inputs.
+ */
+export class INVALID_CONSTRUCTOR_ARGS extends LedgerEntriesError<Code> {
+  constructor() {
+    super({
+      code: Code.INVALID_CONSTRUCTOR_ARGS,
+      message: "Invalid LedgerEntries constructor arguments",
+      details:
+        "LedgerEntries must be initialized with exactly one of 'networkConfig' or 'rpc'.",
+      data: {},
+    });
+  }
+}
+
+/**
+ * Raised when a network config does not provide an RPC URL.
+ */
+export class MISSING_RPC_URL extends LedgerEntriesError<Code> {
+  constructor() {
+    super({
+      code: Code.MISSING_RPC_URL,
+      message: "Missing required argument: rpcUrl",
+      details:
+        "The provided network configuration does not contain an RPC URL, so LedgerEntries cannot create its own RPC client.",
+      diagnostic: {
+        suggestion:
+          "Either provide a network configuration with 'rpcUrl' or pass an RPC Server instance directly.",
+        rootCause:
+          "LedgerEntries needs a live RPC client to perform getLedgerEntries requests.",
+      },
+      data: {},
+    });
+  }
+}
+
+/**
+ * Raised when an invalid Ed25519 account id is provided.
+ */
+export class INVALID_ACCOUNT_ID extends LedgerEntriesError<Code> {
+  /**
+   * Creates the error.
+   *
+   * @param accountId - Invalid account id supplied by the caller.
+   */
+  constructor(accountId: string) {
+    super({
+      code: Code.INVALID_ACCOUNT_ID,
+      message: `Invalid account id: ${accountId}`,
+      details:
+        "The provided account id is not a valid Ed25519 Stellar public key.",
+      data: { accountId },
+    });
+  }
+}
+
+/**
+ * Raised when an invalid contract id is provided.
+ */
+export class INVALID_CONTRACT_ID extends LedgerEntriesError<Code> {
+  /**
+   * Creates the error.
+   *
+   * @param contractId - Invalid contract id supplied by the caller.
+   */
+  constructor(contractId: string) {
+    super({
+      code: Code.INVALID_CONTRACT_ID,
+      message: `Invalid contract id: ${contractId}`,
+      details: "The provided contract id is not a valid Stellar contract id.",
+      data: { contractId },
+    });
+  }
+}
+
+/**
+ * Raised when an invalid claimable-balance id is provided.
+ */
+export class INVALID_CLAIMABLE_BALANCE_ID extends LedgerEntriesError<Code> {
+  /**
+   * Creates the error.
+   *
+   * @param balanceId - Invalid claimable-balance id supplied by the caller.
+   */
+  constructor(balanceId: string) {
+    super({
+      code: Code.INVALID_CLAIMABLE_BALANCE_ID,
+      message: `Invalid claimable balance id: ${balanceId}`,
+      details:
+        "The provided claimable balance id is not a valid Stellar claimable-balance strkey.",
+      data: { balanceId },
+    });
+  }
+}
+
+/**
+ * Raised when an invalid liquidity-pool id is provided.
+ */
+export class INVALID_LIQUIDITY_POOL_ID extends LedgerEntriesError<Code> {
+  /**
+   * Creates the error.
+   *
+   * @param liquidityPoolId - Invalid liquidity-pool id supplied by the caller.
+   */
+  constructor(liquidityPoolId: string) {
+    super({
+      code: Code.INVALID_LIQUIDITY_POOL_ID,
+      message: `Invalid liquidity pool id: ${liquidityPoolId}`,
+      details:
+        "The provided liquidity pool id is not a valid Stellar liquidity-pool strkey.",
+      data: { liquidityPoolId },
+    });
+  }
+}
+
+/**
+ * Raised when a hash argument is not a 32-byte hex string.
+ */
+export class INVALID_HEX_HASH extends LedgerEntriesError<Code> {
+  /**
+   * Creates the error.
+   *
+   * @param hash - Invalid hash value supplied by the caller.
+   */
+  constructor(hash: string) {
+    super({
+      code: Code.INVALID_HEX_HASH,
+      message: `Invalid hash: ${hash}`,
+      details:
+        "The provided hash must be a 64-character hexadecimal string or a 32-byte payload.",
+      data: { hash },
+    });
+  }
+}
+
+/**
+ * Raised when a config-setting id is not recognized.
+ */
+export class INVALID_CONFIG_SETTING_ID extends LedgerEntriesError<Code> {
+  /**
+   * Creates the error.
+   *
+   * @param configSettingId - Invalid config-setting identifier.
+   */
+  constructor(configSettingId: string) {
+    super({
+      code: Code.INVALID_CONFIG_SETTING_ID,
+      message: `Invalid config setting id: ${configSettingId}`,
+      details:
+        "The provided config setting id is not one of the supported Stellar config-setting identifiers.",
+      data: { configSettingId },
+    });
+  }
+}
+
+/**
+ * Raised when a TTL key hash is invalid.
+ */
+export class INVALID_LEDGER_KEY_HASH extends LedgerEntriesError<Code> {
+  constructor() {
+    super({
+      code: Code.INVALID_LEDGER_KEY_HASH,
+      message: "Invalid ledger key hash",
+      details:
+        "The provided TTL key hash must be a valid SHA-256 strkey or a 32-byte payload.",
+      data: {},
+    });
+  }
+}
+
+/**
+ * Raised when a convenience method cannot find the requested entry.
+ */
+export class LEDGER_ENTRY_NOT_FOUND extends LedgerEntriesError<Code> {
+  /**
+   * Creates the error.
+   *
+   * @param kind - Logical ledger-entry kind requested by the caller.
+   * @param key - Encoded ledger-key payload used for the lookup.
+   */
+  constructor(kind: LedgerEntryKind, key: string) {
+    super({
+      code: Code.LEDGER_ENTRY_NOT_FOUND,
+      message: `Ledger entry not found: ${kind}`,
+      details:
+        "No live ledger entry matched the requested key on the connected RPC server.",
+      data: { kind, key },
+    });
+  }
+}
+
+/**
+ * Raised when the RPC response does not match the requested ledger-key type.
+ */
+export class UNEXPECTED_LEDGER_ENTRY_TYPE extends LedgerEntriesError<Code> {
+  /**
+   * Creates the error.
+   *
+   * @param expected - Entry type implied by the requested key.
+   * @param actual - Entry type decoded from the RPC response.
+   */
+  constructor(expected: LedgerEntryKind, actual: LedgerEntryKind) {
+    super({
+      code: Code.UNEXPECTED_LEDGER_ENTRY_TYPE,
+      message: `Unexpected ledger entry type: expected ${expected}, received ${actual}`,
+      details:
+        "The RPC server returned a ledger entry whose decoded type does not match the requested key.",
+      data: { expected, actual },
+    });
+  }
+}
+
+/**
+ * Raised when a contract instance points at a built-in executable instead of wasm.
+ */
+export class CONTRACT_INSTANCE_HAS_NO_WASM_HASH extends LedgerEntriesError<
+  Code
+> {
+  /**
+   * Creates the error.
+   *
+   * @param contractId - Contract id requested by the caller.
+   * @param executableType - Executable type found on the contract instance.
+   */
+  constructor(contractId: string, executableType: string) {
+    super({
+      code: Code.CONTRACT_INSTANCE_HAS_NO_WASM_HASH,
+      message: `Contract instance has no wasm hash: ${contractId}`,
+      details:
+        "The targeted contract instance does not point to a wasm executable, so no contract-code ledger entry can be derived from it.",
+      data: { contractId, executableType },
+    });
+  }
+}
+
+/**
+ * Raised when Stellar RPC does not support querying a ledger-key type.
+ */
+export class UNSUPPORTED_RPC_LEDGER_KEY extends LedgerEntriesError<Code> {
+  /**
+   * Creates the error.
+   *
+   * @param kind - Ledger-key kind rejected by Stellar RPC.
+   */
+  constructor(kind: LedgerEntryKind) {
+    super({
+      code: Code.UNSUPPORTED_RPC_LEDGER_KEY,
+      message: `Unsupported RPC ledger key: ${kind}`,
+      details: kind === "ttl"
+        ? "Current Stellar RPC servers do not allow direct TTL ledger-entry queries via getLedgerEntries."
+        : "The connected Stellar RPC server does not support querying this ledger-key type via getLedgerEntries.",
+      diagnostic: {
+        rootCause:
+          "LedgerEntries uses Stellar RPC getLedgerEntries, but the server rejects this ledger-key type.",
+        suggestion: kind === "ttl"
+          ? "Query the underlying entry instead, or use another data source that exposes TTL metadata."
+          : "Use a different API path that supports this ledger-key type.",
+      },
+      data: { kind },
+    });
+  }
+}

--- a/core/ledger-entries/error.ts
+++ b/core/ledger-entries/error.ts
@@ -73,6 +73,7 @@ export enum Code {
   UNEXPECTED_LEDGER_ENTRY_TYPE = "LDE_010",
   CONTRACT_INSTANCE_HAS_NO_WASM_HASH = "LDE_011",
   UNSUPPORTED_RPC_LEDGER_KEY = "LDE_012",
+  UNSUPPORTED_XDR_VARIANT = "LDE_013",
 }
 
 /**
@@ -334,6 +335,27 @@ export class UNSUPPORTED_RPC_LEDGER_KEY extends LedgerEntriesError<Code> {
           : "Use a different API path that supports this ledger-key type.",
       },
       data: { kind },
+    });
+  }
+}
+
+/**
+ * Raised when a decoded Stellar XDR union variant is unsupported.
+ */
+export class UNSUPPORTED_XDR_VARIANT extends LedgerEntriesError<Code> {
+  /**
+   * Creates the error.
+   *
+   * @param kind High-level XDR union family being decoded.
+   * @param value Unsupported variant name returned by Stellar SDK.
+   */
+  constructor(kind: string, value: string) {
+    super({
+      code: Code.UNSUPPORTED_XDR_VARIANT,
+      message: `Unsupported ${kind} type: ${value}`,
+      details:
+        "The connected Stellar SDK returned an XDR union variant that this LedgerEntries decoder does not currently support.",
+      data: { kind, value },
     });
   }
 }

--- a/core/ledger-entries/error.unit.test.ts
+++ b/core/ledger-entries/error.unit.test.ts
@@ -26,9 +26,8 @@ describe("LedgerEntries errors", () => {
     );
 
     await assertRejects(
-      async () => {
-        throw new E.UNEXPECTED_LEDGER_ENTRY_TYPE("account", "data");
-      },
+      () =>
+        Promise.reject(new E.UNEXPECTED_LEDGER_ENTRY_TYPE("account", "data")),
       E.UNEXPECTED_LEDGER_ENTRY_TYPE,
     );
   });

--- a/core/ledger-entries/error.unit.test.ts
+++ b/core/ledger-entries/error.unit.test.ts
@@ -1,0 +1,35 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import * as E from "@/ledger-entries/error.ts";
+
+describe("LedgerEntries errors", () => {
+  it("exposes stable error codes through direct constructors", async () => {
+    assertEquals(
+      new E.INVALID_CONTRACT_ID("BAD").code,
+      E.Code.INVALID_CONTRACT_ID,
+    );
+    assertEquals(
+      new E.INVALID_CONFIG_SETTING_ID("badSetting").code,
+      E.Code.INVALID_CONFIG_SETTING_ID,
+    );
+    assertEquals(
+      new E.INVALID_LEDGER_KEY_HASH().code,
+      E.Code.INVALID_LEDGER_KEY_HASH,
+    );
+    assertEquals(
+      new E.UNEXPECTED_LEDGER_ENTRY_TYPE("account", "data").code,
+      E.Code.UNEXPECTED_LEDGER_ENTRY_TYPE,
+    );
+    assertEquals(
+      new E.UNSUPPORTED_RPC_LEDGER_KEY("account").code,
+      E.Code.UNSUPPORTED_RPC_LEDGER_KEY,
+    );
+
+    await assertRejects(
+      async () => {
+        throw new E.UNEXPECTED_LEDGER_ENTRY_TYPE("account", "data");
+      },
+      E.UNEXPECTED_LEDGER_ENTRY_TYPE,
+    );
+  });
+});

--- a/core/ledger-entries/index.integration.test.ts
+++ b/core/ledger-entries/index.integration.test.ts
@@ -11,6 +11,7 @@ import {
   buildConfigSettingLedgerKey,
   buildContractInstanceLedgerKey,
   buildDataLedgerKey,
+  buildTtlLedgerKey,
 } from "@/ledger-entries/index.ts";
 import { NetworkConfig } from "@/network/index.ts";
 import { NativeAccount } from "@/account/native/index.ts";
@@ -203,12 +204,14 @@ describe("LedgerEntries integration", disableSanitizeConfig, () => {
     assert(code.hash.length > 0);
   });
 
-  it("surfaces the rpc ttl-query limitation explicitly", async () => {
+  it("surfaces the rpc ttl-query limitation explicitly on generic reads", async () => {
     await assertRejects(
       () =>
-        ledger.ttl({
-          key: buildContractInstanceLedgerKey({ contractId }),
-        }),
+        ledger.get(
+          buildTtlLedgerKey({
+            key: buildContractInstanceLedgerKey({ contractId }),
+          }),
+        ),
       E.UNSUPPORTED_RPC_LEDGER_KEY,
     );
   });

--- a/core/ledger-entries/index.integration.test.ts
+++ b/core/ledger-entries/index.integration.test.ts
@@ -1,0 +1,232 @@
+import { disableSanitizeConfig } from "colibri-internal/tests/disable-sanitize-config.ts";
+import { loadWasmFile } from "colibri-internal/util/load-wasm-file.ts";
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import type { Buffer } from "buffer";
+import { Asset, Operation } from "stellar-sdk";
+import { StellarTestLedger } from "../../test-tooling/mod.ts";
+import {
+  LedgerEntries,
+  buildAccountLedgerKey,
+  buildConfigSettingLedgerKey,
+  buildContractInstanceLedgerKey,
+  buildDataLedgerKey,
+} from "@/ledger-entries/index.ts";
+import { NetworkConfig } from "@/network/index.ts";
+import { NativeAccount } from "@/account/native/index.ts";
+import { LocalSigner } from "@/signer/local/index.ts";
+import { initializeWithFriendbot } from "@/tools/friendbot/initialize-with-friendbot.ts";
+import { createClassicTransactionPipeline } from "@/pipelines/classic-transaction/index.ts";
+import { Contract } from "@/contract/index.ts";
+import * as E from "@/ledger-entries/error.ts";
+import type { TransactionConfig } from "@/common/types/transaction-config/types.ts";
+import type { ContractId } from "@/strkeys/types.ts";
+
+describe("LedgerEntries integration", disableSanitizeConfig, () => {
+  const testLedger = new StellarTestLedger({
+    containerName: `colibri-ledger-entries-${crypto.randomUUID()}`,
+    containerImageVersion: "testing",
+    logLevel: "silent",
+  });
+  const wait = (ms = 500) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  const admin = NativeAccount.fromMasterSigner(LocalSigner.generateRandom());
+  const user = NativeAccount.fromMasterSigner(LocalSigner.generateRandom());
+  const issuer = NativeAccount.fromMasterSigner(LocalSigner.generateRandom());
+  const asset = new Asset("LEDGER", issuer.address());
+  const dataName = "profile";
+  const dataValue = "colibri";
+
+  let networkConfig: NetworkConfig;
+  let classicPipe: ReturnType<typeof createClassicTransactionPipeline>;
+  let ledger: LedgerEntries;
+
+  let adminConfig: TransactionConfig;
+
+  let contractId: ContractId;
+
+  const unwrapCause = (error: unknown): string => {
+    if (!(error instanceof Error)) {
+      return String(error);
+    }
+
+    const meta = (
+      error as Error & {
+        meta?: {
+          cause?: unknown;
+          data?: {
+            simulationResponse?: {
+              error?: string;
+            };
+          };
+        };
+      }
+    ).meta;
+    const simulationError = meta?.data?.simulationResponse?.error;
+
+    if (simulationError) {
+      return `${error.message} ${simulationError}`;
+    }
+
+    const cause = meta?.cause;
+
+    if (cause instanceof Error) {
+      return unwrapCause(cause);
+    }
+
+    return error.message;
+  };
+
+  beforeAll(async () => {
+    await testLedger.start();
+
+    networkConfig = NetworkConfig.CustomNet(
+      await testLedger.getNetworkConfiguration(),
+    );
+    classicPipe = createClassicTransactionPipeline({ networkConfig });
+    ledger = new LedgerEntries({ networkConfig });
+    adminConfig = {
+      fee: "10000000",
+      timeout: 120,
+      source: admin.address(),
+      signers: [admin.signer()],
+    };
+
+    for (const account of [admin, user, issuer]) {
+      await initializeWithFriendbot(
+        networkConfig.friendbotUrl!,
+        account.address(),
+        {
+          rpcUrl: networkConfig.rpcUrl!,
+          allowHttp: networkConfig.allowHttp,
+        },
+      );
+    }
+
+    await classicPipe.run({
+      operations: [
+        Operation.changeTrust({
+          source: user.address(),
+          asset,
+        }),
+      ],
+      config: {
+        fee: "10000000",
+        timeout: 120,
+        source: user.address(),
+        signers: [user.signer()],
+      },
+    });
+
+    await classicPipe.run({
+      operations: [
+        Operation.manageData({
+          source: user.address(),
+          name: dataName,
+          value: dataValue,
+        }),
+      ],
+      config: {
+        fee: "10000000",
+        timeout: 120,
+        source: user.address(),
+        signers: [user.signer()],
+      },
+    });
+
+    const wasm = await loadWasmFile(
+      "./_internal/tests/compiled-contracts/types_harness.wasm",
+    );
+
+    const contract = new Contract({
+      networkConfig,
+      contractConfig: {
+        wasm: wasm as Buffer,
+      },
+    });
+
+    try {
+      await contract.uploadWasm(adminConfig);
+      await contract.deploy({ config: adminConfig });
+    } catch (error) {
+      throw new Error(
+        `Failed to prepare contract fixtures for LedgerEntries integration: ${unwrapCause(error)}`,
+      );
+    }
+
+    contractId = contract.getContractId() as ContractId;
+
+    await wait(1500);
+  });
+
+  afterAll(async () => {
+    await testLedger.stop();
+    await testLedger.destroy();
+  });
+
+  it("reads classic entries through convenience methods", async () => {
+    const accountEntry = await ledger.account({ accountId: user.address() });
+    const trustlineEntry = await ledger.trustline({
+      accountId: user.address(),
+      asset,
+    });
+    const dataEntry = await ledger.data({
+      accountId: user.address(),
+      dataName,
+    });
+
+    assertEquals(accountEntry.type, "account");
+    assertEquals(accountEntry.accountId, user.address());
+    assertEquals(trustlineEntry.type, "trustline");
+    assertEquals(trustlineEntry.accountId, user.address());
+    assertEquals(dataEntry.type, "data");
+    assertEquals(new TextDecoder().decode(dataEntry.dataValue), dataValue);
+  });
+
+  it("reads network config settings", async () => {
+    const configSetting = await ledger.configSetting({
+      configSettingId: "configSettingContractMaxSizeBytes",
+    });
+
+    assertEquals(configSetting.type, "configSetting");
+    assert(typeof configSetting.value === "number");
+    assert((configSetting.value as number) > 0);
+  });
+
+  it("reads contract instance and code entries", async () => {
+    const instance = await ledger.contractInstance({ contractId });
+    const code = await ledger.contractCode({ contractId });
+
+    assertEquals(instance.type, "contractInstance");
+    assertEquals(instance.contractId, contractId);
+    assertEquals(code.type, "contractCode");
+    assert(code.hash.length > 0);
+  });
+
+  it("surfaces the rpc ttl-query limitation explicitly", async () => {
+    await assertRejects(
+      () =>
+        ledger.ttl({
+          key: buildContractInstanceLedgerKey({ contractId }),
+        }),
+      E.UNSUPPORTED_RPC_LEDGER_KEY,
+    );
+  });
+
+  it("supports typed batch reads across entry kinds", async () => {
+    const [accountEntry, dataEntry, contractEntry, configEntry] =
+      await ledger.getMany([
+        buildAccountLedgerKey({ accountId: user.address() }),
+        buildDataLedgerKey({ accountId: user.address(), dataName }),
+        buildContractInstanceLedgerKey({ contractId }),
+        buildConfigSettingLedgerKey({
+          configSettingId: "configSettingContractMaxSizeBytes",
+        }),
+      ] as const);
+
+    assertEquals(accountEntry?.type, "account");
+    assertEquals(dataEntry?.type, "data");
+    assertEquals(contractEntry?.type, "contractInstance");
+    assertEquals(configEntry?.type, "configSetting");
+  });
+});

--- a/core/ledger-entries/index.ts
+++ b/core/ledger-entries/index.ts
@@ -1,0 +1,292 @@
+import { Buffer } from "buffer";
+import { Server } from "stellar-sdk/rpc";
+import type { Api } from "stellar-sdk/rpc";
+import type { xdr } from "stellar-sdk";
+import type { LedgerKeyLike } from "@/common/types/index.ts";
+import * as E from "@/ledger-entries/error.ts";
+import {
+  buildAccountLedgerKey,
+  buildClaimableBalanceLedgerKey,
+  buildConfigSettingLedgerKey,
+  buildContractCodeLedgerKey,
+  buildContractDataLedgerKey,
+  buildContractInstanceLedgerKey,
+  buildDataLedgerKey,
+  buildLiquidityPoolLedgerKey,
+  buildOfferLedgerKey,
+  buildTrustlineLedgerKey,
+  buildTtlLedgerKey,
+} from "@/ledger-entries/keys.ts";
+import {
+  decodeLedgerEntryForKey,
+  detectLedgerEntryKindFromKey,
+} from "@/ledger-entries/decode.ts";
+import type {
+  AccountLedgerEntry,
+  BuildAccountLedgerKeyArgs,
+  BuildClaimableBalanceLedgerKeyArgs,
+  BuildConfigSettingLedgerKeyArgs,
+  BuildContractDataLedgerKeyArgs,
+  BuildContractInstanceLedgerKeyArgs,
+  BuildDataLedgerKeyArgs,
+  BuildLiquidityPoolLedgerKeyArgs,
+  BuildOfferLedgerKeyArgs,
+  BuildTrustlineLedgerKeyArgs,
+  BuildTtlLedgerKeyArgs,
+  ClaimableBalanceLedgerEntry,
+  ConfigSettingLedgerEntry,
+  ContractCodeLedgerEntry,
+  ContractCodeLookupArgs,
+  ContractDataLedgerEntry,
+  ContractInstanceLedgerEntry,
+  DataLedgerEntry,
+  EntryFromLedgerKey,
+  LedgerEntriesConstructorArgs,
+  LedgerEntryKind,
+  LiquidityPoolLedgerEntry,
+  OfferLedgerEntry,
+  RpcLedgerEntriesClient,
+  TrustlineLedgerEntry,
+  TtlLedgerEntry,
+} from "@/ledger-entries/types.ts";
+
+export * from "@/ledger-entries/types.ts";
+export * from "@/ledger-entries/keys.ts";
+
+function toBase64Xdr(key: LedgerKeyLike): string {
+  const encoded = key.toXDR("base64");
+  return typeof encoded === "string"
+    ? encoded
+    : Buffer.from(encoded).toString("base64");
+}
+
+/**
+ * High-level RPC helper for reading and decoding Stellar ledger entries.
+ */
+export class LedgerEntries {
+  /** Bound RPC client used for all ledger-entry reads. */
+  readonly rpc: RpcLedgerEntriesClient;
+
+  /**
+   * Creates a ledger-entry reader bound to either a network config or RPC client.
+   */
+  constructor(args: LedgerEntriesConstructorArgs) {
+    const hasNetworkConfig = "networkConfig" in args && !!args.networkConfig;
+    const hasRpc = "rpc" in args && !!args.rpc;
+
+    if (hasNetworkConfig === hasRpc) {
+      throw new E.INVALID_CONSTRUCTOR_ARGS();
+    }
+
+    if (hasRpc) {
+      this.rpc = args.rpc;
+      return;
+    }
+
+    if (!args.networkConfig.rpcUrl) {
+      throw new E.MISSING_RPC_URL();
+    }
+
+    this.rpc = new Server(args.networkConfig.rpcUrl, {
+      allowHttp: args.networkConfig.allowHttp ?? false,
+    }) as RpcLedgerEntriesClient;
+  }
+
+  /**
+   * Fetches and decodes a single ledger entry, returning `null` when missing.
+   */
+  public async get<TKey extends LedgerKeyLike>(
+    key: TKey,
+  ): Promise<EntryFromLedgerKey<TKey> | null> {
+    const entries = await this.getMany([key] as const);
+    return entries[0] as EntryFromLedgerKey<TKey> | null;
+  }
+
+  /**
+   * Fetches and decodes multiple ledger entries while preserving input order.
+   */
+  public async getMany<const TKeys extends readonly LedgerKeyLike[]>(
+    keys: TKeys,
+  ): Promise<{ [Index in keyof TKeys]: EntryFromLedgerKey<TKeys[Index]> | null }> {
+    if (keys.length === 0) {
+      return [] as {
+        [Index in keyof TKeys]: EntryFromLedgerKey<TKeys[Index]> | null;
+      };
+    }
+
+    for (const key of keys) {
+      const kind = detectLedgerEntryKindFromKey(key as xdr.LedgerKey);
+      if (kind === "ttl") {
+        throw new E.UNSUPPORTED_RPC_LEDGER_KEY(kind);
+      }
+    }
+
+    const response = await this.rpc.getLedgerEntries(...keys);
+    const entriesByKey = new Map(
+      response.entries.map((entry) => [
+        toBase64Xdr(entry.key),
+        entry,
+      ]),
+    );
+
+    const orderedEntries = keys.map((key) => {
+      const entry = entriesByKey.get(toBase64Xdr(key));
+      return entry
+        ? decodeLedgerEntryForKey(
+          key as xdr.LedgerKey,
+          entry as Api.LedgerEntryResult,
+        )
+        : null;
+    });
+
+    return orderedEntries as {
+      [Index in keyof TKeys]: EntryFromLedgerKey<TKeys[Index]> | null;
+    };
+  }
+
+  /**
+   * Reads a native account entry by account id.
+   */
+  public async account(
+    args: BuildAccountLedgerKeyArgs,
+  ): Promise<AccountLedgerEntry> {
+    return await this.requireEntry("account", buildAccountLedgerKey(args));
+  }
+
+  /**
+   * Reads a trustline entry by owner account and asset.
+   */
+  public async trustline(
+    args: BuildTrustlineLedgerKeyArgs,
+  ): Promise<TrustlineLedgerEntry> {
+    return await this.requireEntry("trustline", buildTrustlineLedgerKey(args));
+  }
+
+  /**
+   * Reads an offer entry by seller id and offer id.
+   */
+  public async offer(args: BuildOfferLedgerKeyArgs): Promise<OfferLedgerEntry> {
+    return await this.requireEntry("offer", buildOfferLedgerKey(args));
+  }
+
+  /**
+   * Reads a manage-data entry by account id and data name.
+   */
+  public async data(args: BuildDataLedgerKeyArgs): Promise<DataLedgerEntry> {
+    return await this.requireEntry("data", buildDataLedgerKey(args));
+  }
+
+  /**
+   * Reads a claimable-balance entry by balance id.
+   */
+  public async claimableBalance(
+    args: BuildClaimableBalanceLedgerKeyArgs,
+  ): Promise<ClaimableBalanceLedgerEntry> {
+    return await this.requireEntry(
+      "claimableBalance",
+      buildClaimableBalanceLedgerKey(args),
+    );
+  }
+
+  /**
+   * Reads a liquidity-pool entry by pool id.
+   */
+  public async liquidityPool(
+    args: BuildLiquidityPoolLedgerKeyArgs,
+  ): Promise<LiquidityPoolLedgerEntry> {
+    return await this.requireEntry(
+      "liquidityPool",
+      buildLiquidityPoolLedgerKey(args),
+    );
+  }
+
+  /**
+   * Reads a generic contract-data entry.
+   */
+  public async contractData(
+    args: BuildContractDataLedgerKeyArgs,
+  ): Promise<ContractDataLedgerEntry> {
+    return await this.requireEntry(
+      "contractData",
+      buildContractDataLedgerKey(args),
+    );
+  }
+
+  /**
+   * Reads a contract-instance entry.
+   */
+  public async contractInstance(
+    args: BuildContractInstanceLedgerKeyArgs,
+  ): Promise<ContractInstanceLedgerEntry> {
+    return await this.requireEntry(
+      "contractInstance",
+      buildContractInstanceLedgerKey(args),
+    );
+  }
+
+  /**
+   * Reads a contract-code entry by hash or by resolving a contract instance first.
+   */
+  public async contractCode(
+    args: ContractCodeLookupArgs,
+  ): Promise<ContractCodeLedgerEntry> {
+    if ("hash" in args) {
+      return await this.requireEntry(
+        "contractCode",
+        buildContractCodeLedgerKey(args),
+      );
+    }
+
+    const contractInstance = await this.contractInstance(args);
+    if (contractInstance.executable.type !== "wasm") {
+      throw new E.CONTRACT_INSTANCE_HAS_NO_WASM_HASH(
+        args.contractId,
+        contractInstance.executable.type,
+      );
+    }
+
+    return await this.requireEntry(
+      "contractCode",
+      buildContractCodeLedgerKey({
+        hash: contractInstance.executable.wasmHash,
+      }),
+    );
+  }
+
+  /**
+   * Reads a config-setting entry.
+   */
+  public async configSetting(
+    args: BuildConfigSettingLedgerKeyArgs,
+  ): Promise<ConfigSettingLedgerEntry> {
+    return await this.requireEntry(
+      "configSetting",
+      buildConfigSettingLedgerKey(args),
+    );
+  }
+
+  /**
+   * Reads a TTL entry using either a raw key or its hashed form.
+   */
+  public async ttl(args: BuildTtlLedgerKeyArgs): Promise<TtlLedgerEntry> {
+    return await this.requireEntry("ttl", buildTtlLedgerKey(args));
+  }
+
+  /**
+   * Reads a required entry and raises a typed not-found error when missing.
+   */
+  private async requireEntry<TKey extends LedgerKeyLike>(
+    kind: LedgerEntryKind,
+    key: TKey,
+  ): Promise<EntryFromLedgerKey<TKey>> {
+    const entry = await this.get(key);
+    if (!entry) {
+      throw new E.LEDGER_ENTRY_NOT_FOUND(
+        kind,
+        toBase64Xdr(key),
+      );
+    }
+
+    return entry as EntryFromLedgerKey<TKey>;
+  }
+}

--- a/core/ledger-entries/index.ts
+++ b/core/ledger-entries/index.ts
@@ -1,4 +1,3 @@
-import { Buffer } from "buffer";
 import { Server } from "stellar-sdk/rpc";
 import type { Api } from "stellar-sdk/rpc";
 import type { xdr } from "stellar-sdk";
@@ -20,6 +19,7 @@ import {
   decodeLedgerEntryForKey,
   detectLedgerEntryKindFromKey,
 } from "@/ledger-entries/decode.ts";
+import { toBase64Xdr } from "@/ledger-entries/xdr.ts";
 import type {
   AccountLedgerEntry,
   BuildAccountLedgerKeyArgs,
@@ -49,35 +49,6 @@ import type {
 
 export * from "@/ledger-entries/types.ts";
 export * from "@/ledger-entries/keys.ts";
-
-const BASE64_REGEX =
-  /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
-
-function decodeByteFormBase64(value: Uint8Array): string | null {
-  try {
-    const decoded = new TextDecoder("utf-8", { fatal: true }).decode(value);
-    if (
-      BASE64_REGEX.test(decoded) &&
-      Buffer.from(decoded, "base64").toString("base64") === decoded
-    ) {
-      return decoded;
-    }
-  } catch {
-    // Fall through and treat the payload as raw XDR bytes.
-  }
-
-  return null;
-}
-
-function toBase64Xdr(key: LedgerKeyLike): string {
-  const encoded = key.toXDR("base64");
-  if (typeof encoded === "string") {
-    return encoded;
-  }
-
-  const byteFormBase64 = decodeByteFormBase64(encoded);
-  return byteFormBase64 ?? Buffer.from(encoded).toString("base64");
-}
 
 /**
  * High-level RPC helper for reading and decoding Stellar ledger entries.

--- a/core/ledger-entries/index.ts
+++ b/core/ledger-entries/index.ts
@@ -17,7 +17,6 @@ import {
 } from "@/ledger-entries/keys.ts";
 import {
   decodeLedgerEntryForKey,
-  detectLedgerEntryKindFromKey,
 } from "@/ledger-entries/decode.ts";
 import { toBase64Xdr } from "@/ledger-entries/xdr.ts";
 import type {
@@ -105,9 +104,8 @@ export class LedgerEntries {
     }
 
     for (const key of keys) {
-      const kind = detectLedgerEntryKindFromKey(key as xdr.LedgerKey);
-      if (kind === "ttl") {
-        throw new E.UNSUPPORTED_RPC_LEDGER_KEY(kind);
+      if (key.switch().name === "ttl") {
+        throw new E.UNSUPPORTED_RPC_LEDGER_KEY("ttl");
       }
     }
 

--- a/core/ledger-entries/index.ts
+++ b/core/ledger-entries/index.ts
@@ -15,7 +15,6 @@ import {
   buildLiquidityPoolLedgerKey,
   buildOfferLedgerKey,
   buildTrustlineLedgerKey,
-  buildTtlLedgerKey,
 } from "@/ledger-entries/keys.ts";
 import {
   decodeLedgerEntryForKey,
@@ -32,7 +31,6 @@ import type {
   BuildLiquidityPoolLedgerKeyArgs,
   BuildOfferLedgerKeyArgs,
   BuildTrustlineLedgerKeyArgs,
-  BuildTtlLedgerKeyArgs,
   ClaimableBalanceLedgerEntry,
   ConfigSettingLedgerEntry,
   ContractCodeLedgerEntry,
@@ -47,17 +45,38 @@ import type {
   OfferLedgerEntry,
   RpcLedgerEntriesClient,
   TrustlineLedgerEntry,
-  TtlLedgerEntry,
 } from "@/ledger-entries/types.ts";
 
 export * from "@/ledger-entries/types.ts";
 export * from "@/ledger-entries/keys.ts";
 
+const BASE64_REGEX =
+  /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+function decodeByteFormBase64(value: Uint8Array): string | null {
+  try {
+    const decoded = new TextDecoder("utf-8", { fatal: true }).decode(value);
+    if (
+      BASE64_REGEX.test(decoded) &&
+      Buffer.from(decoded, "base64").toString("base64") === decoded
+    ) {
+      return decoded;
+    }
+  } catch {
+    // Fall through and treat the payload as raw XDR bytes.
+  }
+
+  return null;
+}
+
 function toBase64Xdr(key: LedgerKeyLike): string {
   const encoded = key.toXDR("base64");
-  return typeof encoded === "string"
-    ? encoded
-    : Buffer.from(encoded).toString("base64");
+  if (typeof encoded === "string") {
+    return encoded;
+  }
+
+  const byteFormBase64 = decodeByteFormBase64(encoded);
+  return byteFormBase64 ?? Buffer.from(encoded).toString("base64");
 }
 
 /**
@@ -263,13 +282,6 @@ export class LedgerEntries {
       "configSetting",
       buildConfigSettingLedgerKey(args),
     );
-  }
-
-  /**
-   * Reads a TTL entry using either a raw key or its hashed form.
-   */
-  public async ttl(args: BuildTtlLedgerKeyArgs): Promise<TtlLedgerEntry> {
-    return await this.requireEntry("ttl", buildTtlLedgerKey(args));
   }
 
   /**

--- a/core/ledger-entries/index.unit.test.ts
+++ b/core/ledger-entries/index.unit.test.ts
@@ -410,10 +410,13 @@ describe("LedgerEntries", () => {
     });
 
     it("accepts ledger keys whose base64 serialization returns bytes", async () => {
-      const key = buildAccountLedgerKey({
+      const responseKey = buildAccountLedgerKey({
         accountId: ACCOUNT_ID,
       }) as unknown as xdr.LedgerKey;
-      const originalToXdr = key.toXDR.bind(key);
+      const requestKey = buildAccountLedgerKey({
+        accountId: ACCOUNT_ID,
+      }) as unknown as xdr.LedgerKey;
+      const originalToXdr = requestKey.toXDR.bind(requestKey);
       const accountEntry = new xdr.AccountEntry({
         accountId: Keypair.fromPublicKey(ACCOUNT_ID).xdrAccountId(),
         balance: xdr.Int64.fromString("10"),
@@ -427,7 +430,7 @@ describe("LedgerEntries", () => {
         ext: new xdr.AccountEntryExt(0),
       });
 
-      Object.defineProperty(key, "toXDR", {
+      Object.defineProperty(requestKey, "toXDR", {
         value: (format?: "raw" | "hex" | "base64") => {
           if (format === "base64") {
             return new TextEncoder().encode(String(originalToXdr("base64")));
@@ -445,14 +448,17 @@ describe("LedgerEntries", () => {
         rpc: {
           getLedgerEntries: () => Promise.resolve({
             entries: [
-              makeResult(key, xdr.LedgerEntryData.account(accountEntry)),
+              makeResult(
+                responseKey,
+                xdr.LedgerEntryData.account(accountEntry),
+              ),
             ],
             latestLedger: 1,
           }),
         } as unknown as Server,
       });
 
-      const [entry] = await ledger.getMany([key] as const);
+      const [entry] = await ledger.getMany([requestKey] as const);
 
       assertEquals(entry?.type, "account");
       if (!entry || entry.type !== "account") {
@@ -748,14 +754,16 @@ describe("LedgerEntries", () => {
       );
     });
 
-    it("throws when ttl entries are requested through rpc", async () => {
+    it("throws when ttl entries are requested through generic reads", async () => {
       const ledger = new LedgerEntries({ rpc: makeRpc([]) });
 
       await assertRejects(
         () =>
-          ledger.ttl({
-            key: buildContractInstanceLedgerKey({ contractId: CONTRACT_ID }),
-          }),
+          ledger.get(
+            buildTtlLedgerKey({
+              key: buildContractInstanceLedgerKey({ contractId: CONTRACT_ID }),
+            }),
+          ),
         E.UNSUPPORTED_RPC_LEDGER_KEY,
       );
     });

--- a/core/ledger-entries/index.unit.test.ts
+++ b/core/ledger-entries/index.unit.test.ts
@@ -466,6 +466,64 @@ describe("LedgerEntries", () => {
       }
       assertEquals(entry.balance, 10n);
     });
+
+    it("accepts ledger keys whose serializer returns raw bytes for base64 requests", async () => {
+      const responseKey = buildAccountLedgerKey({
+        accountId: ACCOUNT_ID,
+      }) as unknown as xdr.LedgerKey;
+      const requestKey = buildAccountLedgerKey({
+        accountId: ACCOUNT_ID,
+      }) as unknown as xdr.LedgerKey;
+      const originalToXdr = requestKey.toXDR.bind(requestKey);
+      const accountEntry = new xdr.AccountEntry({
+        accountId: Keypair.fromPublicKey(ACCOUNT_ID).xdrAccountId(),
+        balance: xdr.Int64.fromString("10"),
+        seqNum: xdr.Int64.fromString("1"),
+        numSubEntries: 0,
+        inflationDest: null,
+        flags: 0,
+        homeDomain: "",
+        thresholds: Buffer.from([0, 0, 0, 0]),
+        signers: [],
+        ext: new xdr.AccountEntryExt(0),
+      });
+
+      Object.defineProperty(requestKey, "toXDR", {
+        value: (format?: "raw" | "hex" | "base64") => {
+          if (format === "base64") {
+            return originalToXdr("raw");
+          }
+
+          if (format === "hex") {
+            return originalToXdr("hex");
+          }
+
+          return originalToXdr("raw");
+        },
+      });
+
+      const ledger = new LedgerEntries({
+        rpc: {
+          getLedgerEntries: () => Promise.resolve({
+            entries: [
+              makeResult(
+                responseKey,
+                xdr.LedgerEntryData.account(accountEntry),
+              ),
+            ],
+            latestLedger: 1,
+          }),
+        } as unknown as Server,
+      });
+
+      const [entry] = await ledger.getMany([requestKey] as const);
+
+      assertEquals(entry?.type, "account");
+      if (!entry || entry.type !== "account") {
+        throw new Error("expected account entry");
+      }
+      assertEquals(entry.balance, 10n);
+    });
   });
 
   describe("key builders", () => {

--- a/core/ledger-entries/index.unit.test.ts
+++ b/core/ledger-entries/index.unit.test.ts
@@ -396,7 +396,10 @@ describe("LedgerEntries", () => {
       });
       const withRpc = new LedgerEntries({
         rpc: {
-          getLedgerEntries: async () => ({ entries: [], latestLedger: 1 }),
+          getLedgerEntries: () => Promise.resolve({
+            entries: [],
+            latestLedger: 1,
+          }),
         } as unknown as Server,
       });
 
@@ -440,7 +443,7 @@ describe("LedgerEntries", () => {
 
       const ledger = new LedgerEntries({
         rpc: {
-          getLedgerEntries: async () => ({
+          getLedgerEntries: () => Promise.resolve({
             entries: [
               makeResult(key, xdr.LedgerEntryData.account(accountEntry)),
             ],

--- a/core/ledger-entries/index.unit.test.ts
+++ b/core/ledger-entries/index.unit.test.ts
@@ -1,0 +1,760 @@
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertThrows,
+} from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { Buffer } from "buffer";
+import { Address, Asset, Keypair, xdr } from "stellar-sdk";
+import type { Api, Server } from "stellar-sdk/rpc";
+import { NetworkConfig } from "@/network/index.ts";
+import { StrKey } from "@/strkeys/index.ts";
+import type { LedgerKeyLike } from "@/common/types/index.ts";
+import {
+  buildAccountLedgerKey,
+  buildClaimableBalanceLedgerKey,
+  buildConfigSettingLedgerKey,
+  buildContractCodeLedgerKey,
+  buildContractDataLedgerKey,
+  buildContractInstanceLedgerKey,
+  buildDataLedgerKey,
+  buildLiquidityPoolLedgerKey,
+  buildOfferLedgerKey,
+  buildTrustlineLedgerKey,
+  buildTtlLedgerKey,
+  hashLedgerKey,
+  LedgerEntries,
+} from "@/ledger-entries/index.ts";
+import { decodeLedgerEntry } from "@/ledger-entries/decode.ts";
+import * as E from "@/ledger-entries/error.ts";
+import type {
+  ClaimableBalanceId,
+  ContractId,
+  Ed25519PublicKey,
+  LiquidityPoolId,
+  Sha256Hash,
+} from "@/strkeys/types.ts";
+
+const ACCOUNT_ID = Keypair.random().publicKey() as Ed25519PublicKey;
+const SECOND_ACCOUNT_ID = Keypair.random().publicKey() as Ed25519PublicKey;
+const ISSUER = Keypair.random().publicKey() as Ed25519PublicKey;
+const CONTRACT_ID = StrKey.encodeContract(Buffer.alloc(32, 9)) as ContractId;
+const LIQUIDITY_POOL_ID = StrKey.encodeLiquidityPool(
+  Buffer.alloc(32, 8),
+) as LiquidityPoolId;
+const CLAIMABLE_BALANCE_ID =
+  "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU" as ClaimableBalanceId;
+const DATA_NAME = "profile";
+const OFFER_ID = 17n;
+const ASSET = new Asset("USD", ISSUER);
+
+function makeRpc(entries: Api.LedgerEntryResult[]): Server {
+  const byKey = new Map(
+    entries.map((entry) => [entry.key.toXDR("base64"), entry]),
+  );
+
+  return {
+    getLedgerEntries: (...keys: xdr.LedgerKey[]) =>
+      Promise.resolve({
+        entries: keys.flatMap((key) => {
+          const entry = byKey.get(key.toXDR("base64"));
+          return entry ? [entry] : [];
+        }),
+        latestLedger: 123456,
+      }),
+  } as unknown as Server;
+}
+
+function makeResult(
+  key: LedgerKeyLike,
+  val: xdr.LedgerEntryData,
+  extras: Partial<Api.LedgerEntryResult> = {},
+): Api.LedgerEntryResult {
+  return {
+    key: key as xdr.LedgerKey,
+    val,
+    ...extras,
+  };
+}
+
+function makeAccountResult(): Api.LedgerEntryResult {
+  const key = buildAccountLedgerKey({ accountId: ACCOUNT_ID });
+  const val = xdr.LedgerEntryData.account(
+    new xdr.AccountEntry({
+      accountId: Keypair.fromPublicKey(ACCOUNT_ID).xdrAccountId(),
+      balance: xdr.Int64.fromString("1000"),
+      seqNum: xdr.Int64.fromString("42"),
+      numSubEntries: 3,
+      inflationDest: Keypair.fromPublicKey(SECOND_ACCOUNT_ID).xdrAccountId(),
+      flags: xdr.AccountFlags.authRequiredFlag().value |
+        xdr.AccountFlags.authClawbackEnabledFlag().value,
+      homeDomain: "colibri.dev",
+      thresholds: Buffer.from([1, 2, 3, 4]),
+      signers: [
+        new xdr.Signer({
+          key: xdr.SignerKey.signerKeyTypeEd25519(
+            Keypair.fromPublicKey(ACCOUNT_ID).rawPublicKey(),
+          ),
+          weight: 10,
+        }),
+      ],
+      ext: new xdr.AccountEntryExt(0),
+    }),
+  );
+
+  return makeResult(key, val, { lastModifiedLedgerSeq: 10 });
+}
+
+function makeTrustlineResult(): Api.LedgerEntryResult {
+  const key = buildTrustlineLedgerKey({ accountId: ACCOUNT_ID, asset: ASSET });
+  const val = xdr.LedgerEntryData.trustline(
+    new xdr.TrustLineEntry({
+      accountId: Keypair.fromPublicKey(ACCOUNT_ID).xdrAccountId(),
+      asset: ASSET.toTrustLineXDRObject() as xdr.TrustLineAsset,
+      balance: xdr.Int64.fromString("500"),
+      limit: xdr.Int64.fromString("1000"),
+      flags: xdr.TrustLineFlags.authorizedFlag().value,
+      ext: new xdr.TrustLineEntryExt(
+        1,
+        new xdr.TrustLineEntryV1({
+          liabilities: new xdr.Liabilities({
+            buying: xdr.Int64.fromString("11"),
+            selling: xdr.Int64.fromString("22"),
+          }),
+          ext: new xdr.TrustLineEntryV1Ext(0),
+        }),
+      ),
+    }),
+  );
+
+  return makeResult(key, val);
+}
+
+function makeOfferResult(): Api.LedgerEntryResult {
+  const key = buildOfferLedgerKey({
+    sellerId: ACCOUNT_ID,
+    offerId: OFFER_ID,
+  });
+  const val = xdr.LedgerEntryData.offer(
+    new xdr.OfferEntry({
+      sellerId: Keypair.fromPublicKey(ACCOUNT_ID).xdrAccountId(),
+      offerId: xdr.Int64.fromString(String(OFFER_ID)),
+      selling: Asset.native().toXDRObject(),
+      buying: ASSET.toXDRObject(),
+      amount: xdr.Int64.fromString("77"),
+      price: new xdr.Price({ n: 3, d: 2 }),
+      flags: xdr.OfferEntryFlags.passiveFlag().value,
+      ext: new xdr.OfferEntryExt(0),
+    }),
+  );
+
+  return makeResult(key, val);
+}
+
+function makeDataResult(): Api.LedgerEntryResult {
+  const key = buildDataLedgerKey({
+    accountId: ACCOUNT_ID,
+    dataName: DATA_NAME,
+  });
+  const val = xdr.LedgerEntryData.data(
+    new xdr.DataEntry({
+      accountId: Keypair.fromPublicKey(ACCOUNT_ID).xdrAccountId(),
+      dataName: DATA_NAME,
+      dataValue: Buffer.from("hello"),
+      ext: new xdr.DataEntryExt(0),
+    }),
+  );
+
+  return makeResult(key, val);
+}
+
+function makeClaimableBalanceResult(): Api.LedgerEntryResult {
+  const key = buildClaimableBalanceLedgerKey({
+    balanceId: CLAIMABLE_BALANCE_ID,
+  });
+  const val = xdr.LedgerEntryData.claimableBalance(
+    new xdr.ClaimableBalanceEntry({
+      balanceId: xdr.ClaimableBalanceId.fromXDR(
+        xdr.ClaimableBalanceId.claimableBalanceIdTypeV0(
+          Buffer.from(StrKey.decodeClaimableBalance(CLAIMABLE_BALANCE_ID))
+            .subarray(1),
+        ).toXDR(),
+      ),
+      claimants: [
+        xdr.Claimant.claimantTypeV0(
+          new xdr.ClaimantV0({
+            destination: Keypair.fromPublicKey(SECOND_ACCOUNT_ID)
+              .xdrAccountId(),
+            predicate: xdr.ClaimPredicate.claimPredicateBeforeRelativeTime(
+              xdr.Int64.fromString("3600"),
+            ),
+          }),
+        ),
+      ],
+      asset: Asset.native().toXDRObject(),
+      amount: xdr.Int64.fromString("99"),
+      ext: new xdr.ClaimableBalanceEntryExt(
+        1,
+        new xdr.ClaimableBalanceEntryExtensionV1({
+          ext: new xdr.ClaimableBalanceEntryExtensionV1Ext(0),
+          flags: xdr.ClaimableBalanceFlags.claimableBalanceClawbackEnabledFlag()
+            .value,
+        }),
+      ),
+    }),
+  );
+
+  return makeResult(key, val);
+}
+
+function makeLiquidityPoolResult(): Api.LedgerEntryResult {
+  const key = buildLiquidityPoolLedgerKey({
+    liquidityPoolId: LIQUIDITY_POOL_ID,
+  });
+  const val = xdr.LedgerEntryData.liquidityPool(
+    new xdr.LiquidityPoolEntry({
+      liquidityPoolId: Buffer.from(
+        StrKey.decodeLiquidityPool(LIQUIDITY_POOL_ID),
+      ) as unknown as xdr.PoolId,
+      body: xdr.LiquidityPoolEntryBody.liquidityPoolConstantProduct(
+        new xdr.LiquidityPoolEntryConstantProduct({
+          params: new xdr.LiquidityPoolConstantProductParameters({
+            assetA: Asset.native().toXDRObject(),
+            assetB: ASSET.toXDRObject(),
+            fee: 30,
+          }),
+          reserveA: xdr.Int64.fromString("100"),
+          reserveB: xdr.Int64.fromString("200"),
+          totalPoolShares: xdr.Int64.fromString("300"),
+          poolSharesTrustLineCount: xdr.Int64.fromString("2"),
+        }),
+      ),
+    }),
+  );
+
+  return makeResult(key, val);
+}
+
+function makeContractDataResult(): Api.LedgerEntryResult {
+  const key = buildContractDataLedgerKey({
+    contractId: CONTRACT_ID,
+    key: xdr.ScVal.scvSymbol("greeting"),
+  });
+  const val = xdr.LedgerEntryData.contractData(
+    new xdr.ContractDataEntry({
+      ext: new xdr.ExtensionPoint(0),
+      contract: Address.fromString(CONTRACT_ID).toScAddress(),
+      key: xdr.ScVal.scvSymbol("greeting"),
+      durability: xdr.ContractDataDurability.persistent(),
+      val: xdr.ScVal.scvString("hello"),
+    }),
+  );
+
+  return makeResult(key, val, { liveUntilLedgerSeq: 999 });
+}
+
+function makeContractInstanceResult(
+  executable: xdr.ContractExecutable = xdr.ContractExecutable
+    .contractExecutableWasm(Buffer.from("ab".repeat(32), "hex")),
+): Api.LedgerEntryResult {
+  const key = buildContractInstanceLedgerKey({ contractId: CONTRACT_ID });
+  const val = xdr.LedgerEntryData.contractData(
+    new xdr.ContractDataEntry({
+      ext: new xdr.ExtensionPoint(0),
+      contract: Address.fromString(CONTRACT_ID).toScAddress(),
+      key: xdr.ScVal.scvLedgerKeyContractInstance(),
+      durability: xdr.ContractDataDurability.persistent(),
+      val: xdr.ScVal.scvContractInstance(
+        new xdr.ScContractInstance({
+          executable,
+          storage: [
+            new xdr.ScMapEntry({
+              key: xdr.ScVal.scvSymbol("count"),
+              val: xdr.ScVal.scvU32(7),
+            }),
+          ],
+        }),
+      ),
+    }),
+  );
+
+  return makeResult(key, val);
+}
+
+function makeContractCodeResult(): Api.LedgerEntryResult {
+  const key = buildContractCodeLedgerKey({ hash: "ab".repeat(32) });
+  const val = xdr.LedgerEntryData.contractCode(
+    new xdr.ContractCodeEntry({
+      ext: new xdr.ContractCodeEntryExt(
+        1,
+        new xdr.ContractCodeEntryV1({
+          ext: new xdr.ExtensionPoint(0),
+          costInputs: new xdr.ContractCodeCostInputs({
+            ext: new xdr.ExtensionPoint(0),
+            nInstructions: 1,
+            nFunctions: 2,
+            nGlobals: 3,
+            nTableEntries: 4,
+            nTypes: 5,
+            nDataSegments: 6,
+            nElemSegments: 7,
+            nImports: 8,
+            nExports: 9,
+            nDataSegmentBytes: 10,
+          }),
+        }),
+      ),
+      hash: Buffer.from("ab".repeat(32), "hex"),
+      code: Buffer.from([1, 2, 3, 4]),
+    }),
+  );
+
+  return makeResult(key, val);
+}
+
+function makeConfigSettingResult(): Api.LedgerEntryResult {
+  const key = buildConfigSettingLedgerKey({
+    configSettingId: "configSettingContractMaxSizeBytes",
+  });
+  const val = xdr.LedgerEntryData.configSetting(
+    xdr.ConfigSettingEntry.configSettingContractMaxSizeBytes(65536),
+  );
+
+  return makeResult(key, val);
+}
+
+function makeTtlResult(): Api.LedgerEntryResult {
+  const contractInstanceKey = buildContractInstanceLedgerKey({
+    contractId: CONTRACT_ID,
+  });
+  const ttlHash = hashLedgerKey(contractInstanceKey) as Sha256Hash;
+  const key = buildTtlLedgerKey({ keyHash: ttlHash });
+  const val = xdr.LedgerEntryData.ttl(
+    new xdr.TtlEntry({
+      keyHash: Buffer.from(StrKey.decodeSha256Hash(ttlHash)),
+      liveUntilLedgerSeq: 777,
+    }),
+  );
+
+  return makeResult(key, val);
+}
+
+describe("LedgerEntries", () => {
+  describe("constructor", () => {
+    it("accepts a network config", () => {
+      const ledger = new LedgerEntries({
+        networkConfig: NetworkConfig.CustomNet({
+          networkPassphrase: "Standalone Network ; February 2017",
+          rpcUrl: "http://localhost:8000",
+          allowHttp: true,
+        }),
+      });
+
+      assertExists(ledger.rpc);
+    });
+
+    it("accepts a preconfigured rpc instance", () => {
+      const rpc = makeRpc([]);
+      const ledger = new LedgerEntries({ rpc });
+
+      assertEquals(ledger.rpc, rpc);
+    });
+
+    it("throws when both constructor styles are provided", () => {
+      assertThrows(
+        () =>
+          new LedgerEntries({
+            rpc: makeRpc([]),
+            networkConfig: NetworkConfig.TestNet(),
+          } as never),
+        E.INVALID_CONSTRUCTOR_ARGS,
+      );
+    });
+
+    it("throws when the network config has no rpc url", () => {
+      assertThrows(
+        () =>
+          new LedgerEntries({
+            networkConfig: NetworkConfig.CustomNet({
+              networkPassphrase: "Standalone Network ; February 2017",
+            }),
+          }),
+        E.MISSING_RPC_URL,
+      );
+    });
+  });
+
+  describe("public api", () => {
+    it("defaults allowHttp to false and supports empty batch reads", async () => {
+      const withNetworkConfig = new LedgerEntries({
+        networkConfig: NetworkConfig.CustomNet({
+          networkPassphrase: "Standalone Network ; February 2017",
+          rpcUrl: "https://rpc.example.com",
+        }),
+      });
+      const withRpc = new LedgerEntries({
+        rpc: {
+          getLedgerEntries: async () => ({ entries: [], latestLedger: 1 }),
+        } as unknown as Server,
+      });
+
+      const entries = await withRpc.getMany([] as const);
+
+      assertExists(withNetworkConfig.rpc);
+      assertEquals(entries, []);
+    });
+
+    it("accepts ledger keys whose base64 serialization returns bytes", async () => {
+      const key = buildAccountLedgerKey({
+        accountId: ACCOUNT_ID,
+      }) as unknown as xdr.LedgerKey;
+      const originalToXdr = key.toXDR.bind(key);
+      const accountEntry = new xdr.AccountEntry({
+        accountId: Keypair.fromPublicKey(ACCOUNT_ID).xdrAccountId(),
+        balance: xdr.Int64.fromString("10"),
+        seqNum: xdr.Int64.fromString("1"),
+        numSubEntries: 0,
+        inflationDest: null,
+        flags: 0,
+        homeDomain: "",
+        thresholds: Buffer.from([0, 0, 0, 0]),
+        signers: [],
+        ext: new xdr.AccountEntryExt(0),
+      });
+
+      Object.defineProperty(key, "toXDR", {
+        value: (format?: "raw" | "hex" | "base64") => {
+          if (format === "base64") {
+            return new TextEncoder().encode(String(originalToXdr("base64")));
+          }
+
+          if (format === "hex") {
+            return originalToXdr("hex");
+          }
+
+          return originalToXdr("raw");
+        },
+      });
+
+      const ledger = new LedgerEntries({
+        rpc: {
+          getLedgerEntries: async () => ({
+            entries: [
+              makeResult(key, xdr.LedgerEntryData.account(accountEntry)),
+            ],
+            latestLedger: 1,
+          }),
+        } as unknown as Server,
+      });
+
+      const [entry] = await ledger.getMany([key] as const);
+
+      assertEquals(entry?.type, "account");
+      if (!entry || entry.type !== "account") {
+        throw new Error("expected account entry");
+      }
+      assertEquals(entry.balance, 10n);
+    });
+  });
+
+  describe("key builders", () => {
+    it("builds all supported ledger-key variants", () => {
+      const account = buildAccountLedgerKey({ accountId: ACCOUNT_ID });
+      const trustline = buildTrustlineLedgerKey({
+        accountId: ACCOUNT_ID,
+        asset: ASSET,
+      });
+      const offer = buildOfferLedgerKey({
+        sellerId: ACCOUNT_ID,
+        offerId: OFFER_ID,
+      });
+      const data = buildDataLedgerKey({
+        accountId: ACCOUNT_ID,
+        dataName: DATA_NAME,
+      });
+      const claimableBalance = buildClaimableBalanceLedgerKey({
+        balanceId: CLAIMABLE_BALANCE_ID,
+      });
+      const liquidityPool = buildLiquidityPoolLedgerKey({
+        liquidityPoolId: LIQUIDITY_POOL_ID,
+      });
+      const contractData = buildContractDataLedgerKey({
+        contractId: CONTRACT_ID,
+        key: xdr.ScVal.scvSymbol("hello"),
+      });
+      const contractInstance = buildContractInstanceLedgerKey({
+        contractId: CONTRACT_ID,
+      });
+      const contractCode = buildContractCodeLedgerKey({
+        hash: "ab".repeat(32),
+      });
+      const configSetting = buildConfigSettingLedgerKey({
+        configSettingId: "configSettingContractMaxSizeBytes",
+      });
+      const ttl = buildTtlLedgerKey({ key: contractInstance });
+
+      assertEquals(account.switch().name, "account");
+      assertEquals(trustline.switch().name, "trustline");
+      assertEquals(offer.switch().name, "offer");
+      assertEquals(data.switch().name, "data");
+      assertEquals(claimableBalance.switch().name, "claimableBalance");
+      assertEquals(liquidityPool.switch().name, "liquidityPool");
+      assertEquals(contractData.switch().name, "contractData");
+      assertEquals(contractInstance.switch().name, "contractData");
+      assertEquals(contractCode.switch().name, "contractCode");
+      assertEquals(configSetting.switch().name, "configSetting");
+      assertEquals(ttl.switch().name, "ttl");
+    });
+
+    it("validates string inputs on the builders", () => {
+      assertThrows(
+        () => buildAccountLedgerKey({ accountId: "BAD" as Ed25519PublicKey }),
+        E.INVALID_ACCOUNT_ID,
+      );
+      assertThrows(
+        () =>
+          buildClaimableBalanceLedgerKey({
+            balanceId: "BAD" as ClaimableBalanceId,
+          }),
+        E.INVALID_CLAIMABLE_BALANCE_ID,
+      );
+      assertThrows(
+        () =>
+          buildLiquidityPoolLedgerKey({
+            liquidityPoolId: "BAD" as LiquidityPoolId,
+          }),
+        E.INVALID_LIQUIDITY_POOL_ID,
+      );
+      assertThrows(
+        () =>
+          buildContractCodeLedgerKey({
+            hash: "not-hex",
+          }),
+        E.INVALID_HEX_HASH,
+      );
+    });
+  });
+
+  describe("decoding", () => {
+    const entries = [
+      makeAccountResult(),
+      makeTrustlineResult(),
+      makeOfferResult(),
+      makeDataResult(),
+      makeClaimableBalanceResult(),
+      makeLiquidityPoolResult(),
+      makeContractDataResult(),
+      makeContractInstanceResult(),
+      makeContractCodeResult(),
+      makeConfigSettingResult(),
+      makeTtlResult(),
+    ];
+
+    const ledger = new LedgerEntries({ rpc: makeRpc(entries) });
+
+    it("decodes account entries", async () => {
+      const entry = await ledger.account({ accountId: ACCOUNT_ID });
+
+      assertEquals(entry.type, "account");
+      assertEquals(entry.accountId, ACCOUNT_ID);
+      assertEquals(entry.balance, 1000n);
+      assertEquals(entry.sequenceNumber, 42n);
+      assertEquals(entry.flags.authRequired, true);
+      assertEquals(entry.flags.authClawbackEnabled, true);
+      assertEquals(entry.thresholds.high, 4);
+      assertEquals(entry.signers[0].key.type, "ed25519");
+      assertExists(entry.xdr.key);
+    });
+
+    it("decodes trustline entries", async () => {
+      const entry = await ledger.trustline({
+        accountId: ACCOUNT_ID,
+        asset: ASSET,
+      });
+
+      assertEquals(entry.type, "trustline");
+      assertEquals(entry.balance, 500n);
+      assertEquals(entry.limit, 1000n);
+      assertEquals(entry.flags.authorized, true);
+      assertEquals(entry.liabilities?.selling, 22n);
+    });
+
+    it("decodes offer entries", async () => {
+      const entry = await ledger.offer({
+        sellerId: ACCOUNT_ID,
+        offerId: OFFER_ID,
+      });
+
+      assertEquals(entry.type, "offer");
+      assertEquals(entry.offerId, OFFER_ID);
+      assertEquals(entry.amount, 77n);
+      assertEquals(entry.price.n, 3);
+      assertEquals(entry.flags.passive, true);
+    });
+
+    it("decodes data entries", async () => {
+      const entry = await ledger.data({
+        accountId: ACCOUNT_ID,
+        dataName: DATA_NAME,
+      });
+
+      assertEquals(entry.type, "data");
+      assertEquals(entry.dataName, DATA_NAME);
+      assertEquals(new TextDecoder().decode(entry.dataValue), "hello");
+    });
+
+    it("decodes claimable balance entries", async () => {
+      const entry = await ledger.claimableBalance({
+        balanceId: CLAIMABLE_BALANCE_ID,
+      });
+
+      assertEquals(entry.type, "claimableBalance");
+      assertEquals(entry.balanceId, CLAIMABLE_BALANCE_ID);
+      assertEquals(entry.amount, 99n);
+      assertEquals(entry.flags.clawbackEnabled, true);
+      assertEquals(entry.claimants[0].predicate.type, "beforeRelativeTime");
+    });
+
+    it("decodes liquidity pool entries", async () => {
+      const entry = await ledger.liquidityPool({
+        liquidityPoolId: LIQUIDITY_POOL_ID,
+      });
+
+      assertEquals(entry.type, "liquidityPool");
+      assertEquals(entry.liquidityPoolId, LIQUIDITY_POOL_ID);
+      assertEquals(entry.reserveA, 100n);
+      assertEquals(entry.poolSharesTrustLineCount, 2n);
+    });
+
+    it("decodes generic contract data entries", async () => {
+      const entry = await ledger.contractData({
+        contractId: CONTRACT_ID,
+        key: xdr.ScVal.scvSymbol("greeting"),
+      });
+
+      assertEquals(entry.type, "contractData");
+      assertEquals(entry.contractId, CONTRACT_ID);
+      assertEquals(entry.durability, "persistent");
+      assertEquals(entry.key, "greeting");
+      assertEquals(entry.value, "hello");
+      assertEquals(entry.liveUntilLedgerSeq, 999);
+    });
+
+    it("decodes contract instance entries", async () => {
+      const entry = await ledger.contractInstance({ contractId: CONTRACT_ID });
+
+      assertEquals(entry.type, "contractInstance");
+      assertEquals(entry.contractId, CONTRACT_ID);
+      assertEquals(entry.executable.type, "wasm");
+      assertEquals((entry.storage as Record<string, unknown>)["count"], 7);
+    });
+
+    it("decodes contract code entries", async () => {
+      const entry = await ledger.contractCode({ hash: "ab".repeat(32) });
+
+      assertEquals(entry.type, "contractCode");
+      assertEquals(entry.hash, "ab".repeat(32));
+      assertEquals(entry.code.length, 4);
+      assertExists(entry.costInputs);
+    });
+
+    it("can resolve contract code from a contract instance", async () => {
+      const entry = await ledger.contractCode({ contractId: CONTRACT_ID });
+
+      assertEquals(entry.type, "contractCode");
+      assertEquals(entry.hash, "ab".repeat(32));
+    });
+
+    it("decodes config setting entries", async () => {
+      const entry = await ledger.configSetting({
+        configSettingId: "configSettingContractMaxSizeBytes",
+      });
+
+      assertEquals(entry.type, "configSetting");
+      assertEquals(entry.configSettingId, "configSettingContractMaxSizeBytes");
+      assertEquals(entry.value, 65536);
+    });
+
+    it("decodes ttl entries", () => {
+      const ttlHash = hashLedgerKey(
+        buildContractInstanceLedgerKey({ contractId: CONTRACT_ID }),
+      ) as Sha256Hash;
+      const entry = decodeLedgerEntry(makeTtlResult());
+
+      assertEquals(entry.type, "ttl");
+      assert(entry.type === "ttl");
+      assertEquals(entry.keyHash, ttlHash);
+      assertEquals(entry.expiresAtLedger, 777);
+    });
+
+    it("preserves order and nulls in getMany", async () => {
+      const missingKey = buildDataLedgerKey({
+        accountId: SECOND_ACCOUNT_ID,
+        dataName: "missing",
+      });
+      const [account, missing, configSetting] = await ledger.getMany(
+        [
+          buildAccountLedgerKey({ accountId: ACCOUNT_ID }),
+          missingKey,
+          buildConfigSettingLedgerKey({
+            configSettingId: "configSettingContractMaxSizeBytes",
+          }),
+        ] as const,
+      );
+
+      assertEquals(account?.type, "account");
+      assertEquals(missing, null);
+      assertEquals(configSetting?.type, "configSetting");
+    });
+  });
+
+  describe("errors", () => {
+    it("throws not found for convenience methods", async () => {
+      const ledger = new LedgerEntries({ rpc: makeRpc([]) });
+
+      await assertRejects(
+        () => ledger.account({ accountId: ACCOUNT_ID }),
+        E.LEDGER_ENTRY_NOT_FOUND,
+      );
+    });
+
+    it("returns null for missing generic reads", async () => {
+      const ledger = new LedgerEntries({ rpc: makeRpc([]) });
+
+      const entry = await ledger.get(
+        buildAccountLedgerKey({ accountId: ACCOUNT_ID }),
+      );
+
+      assertEquals(entry, null);
+    });
+
+    it("throws when resolving contract code from a non-wasm contract instance", async () => {
+      const ledger = new LedgerEntries({
+        rpc: makeRpc([
+          makeContractInstanceResult(
+            xdr.ContractExecutable.contractExecutableStellarAsset(),
+          ),
+        ]),
+      });
+
+      await assertRejects(
+        () => ledger.contractCode({ contractId: CONTRACT_ID }),
+        E.CONTRACT_INSTANCE_HAS_NO_WASM_HASH,
+      );
+    });
+
+    it("throws when ttl entries are requested through rpc", async () => {
+      const ledger = new LedgerEntries({ rpc: makeRpc([]) });
+
+      await assertRejects(
+        () =>
+          ledger.ttl({
+            key: buildContractInstanceLedgerKey({ contractId: CONTRACT_ID }),
+          }),
+        E.UNSUPPORTED_RPC_LEDGER_KEY,
+      );
+    });
+  });
+});

--- a/core/ledger-entries/keys.ts
+++ b/core/ledger-entries/keys.ts
@@ -1,0 +1,399 @@
+import { Address, Contract as StellarContract, Keypair, hash, xdr } from "stellar-sdk";
+import { Buffer } from "buffer";
+import type { LedgerKeyLike } from "@/common/types/index.ts";
+import { StrKey } from "@/strkeys/index.ts";
+import * as E from "@/ledger-entries/error.ts";
+import type {
+  AccountLedgerEntry,
+  AccountLedgerKey,
+  AnyLedgerEntry,
+  BuildAccountLedgerKeyArgs,
+  BuildClaimableBalanceLedgerKeyArgs,
+  BuildConfigSettingLedgerKeyArgs,
+  BuildContractCodeLedgerKeyArgs,
+  BuildContractDataLedgerKeyArgs,
+  BuildContractInstanceLedgerKeyArgs,
+  BuildDataLedgerKeyArgs,
+  BuildLiquidityPoolLedgerKeyArgs,
+  BuildOfferLedgerKeyArgs,
+  BuildTrustlineLedgerKeyArgs,
+  BuildTtlLedgerKeyArgs,
+  ClaimableBalanceLedgerEntry,
+  ClaimableBalanceLedgerKey,
+  ConfigSettingIdName,
+  ConfigSettingLedgerEntry,
+  ConfigSettingLedgerKey,
+  ContractCodeLedgerEntry,
+  ContractCodeLedgerKey,
+  ContractDataDurabilityName,
+  ContractDataLedgerEntry,
+  ContractDataLedgerKey,
+  ContractInstanceLedgerEntry,
+  ContractInstanceLedgerKey,
+  DataLedgerEntry,
+  DataLedgerKey,
+  LiquidityPoolLedgerEntry,
+  LiquidityPoolLedgerKey,
+  OfferLedgerEntry,
+  OfferLedgerKey,
+  TrustlineLedgerEntry,
+  TrustlineLedgerKey,
+  TtlLedgerEntry,
+  TtlLedgerKey,
+  TypedLedgerKey,
+} from "@/ledger-entries/types.ts";
+import type { Sha256Hash } from "@/strkeys/types.ts";
+
+const HEX_32_BYTE_REGEX = /^[0-9a-f]{64}$/i;
+
+const CONFIG_SETTING_ID_BUILDERS: Record<
+  ConfigSettingIdName,
+  () => xdr.ConfigSettingId
+> = {
+  configSettingContractMaxSizeBytes:
+    xdr.ConfigSettingId.configSettingContractMaxSizeBytes,
+  configSettingContractComputeV0:
+    xdr.ConfigSettingId.configSettingContractComputeV0,
+  configSettingContractLedgerCostV0:
+    xdr.ConfigSettingId.configSettingContractLedgerCostV0,
+  configSettingContractHistoricalDataV0:
+    xdr.ConfigSettingId.configSettingContractHistoricalDataV0,
+  configSettingContractEventsV0:
+    xdr.ConfigSettingId.configSettingContractEventsV0,
+  configSettingContractBandwidthV0:
+    xdr.ConfigSettingId.configSettingContractBandwidthV0,
+  configSettingContractCostParamsCpuInstructions:
+    xdr.ConfigSettingId.configSettingContractCostParamsCpuInstructions,
+  configSettingContractCostParamsMemoryBytes:
+    xdr.ConfigSettingId.configSettingContractCostParamsMemoryBytes,
+  configSettingContractDataKeySizeBytes:
+    xdr.ConfigSettingId.configSettingContractDataKeySizeBytes,
+  configSettingContractDataEntrySizeBytes:
+    xdr.ConfigSettingId.configSettingContractDataEntrySizeBytes,
+  configSettingStateArchival: xdr.ConfigSettingId.configSettingStateArchival,
+  configSettingContractExecutionLanes:
+    xdr.ConfigSettingId.configSettingContractExecutionLanes,
+  configSettingLiveSorobanStateSizeWindow:
+    xdr.ConfigSettingId.configSettingLiveSorobanStateSizeWindow,
+  configSettingEvictionIterator:
+    xdr.ConfigSettingId.configSettingEvictionIterator,
+  configSettingContractParallelComputeV0:
+    xdr.ConfigSettingId.configSettingContractParallelComputeV0,
+  configSettingContractLedgerCostExtV0:
+    xdr.ConfigSettingId.configSettingContractLedgerCostExtV0,
+  configSettingScpTiming: xdr.ConfigSettingId.configSettingScpTiming,
+};
+
+function brandLedgerKey<TEntry extends AnyLedgerEntry>(
+  key: xdr.LedgerKey,
+): TypedLedgerKey<TEntry> {
+  return key as TypedLedgerKey<TEntry>;
+}
+
+function toRawXdrBuffer(value: LedgerKeyLike): Buffer {
+  const encoded = value.toXDR("base64");
+  return typeof encoded === "string"
+    ? Buffer.from(encoded, "base64")
+    : Buffer.from(encoded);
+}
+
+function normalizeScVal(value: { toXDR(format?: "raw" | "hex" | "base64"): string | Uint8Array }): xdr.ScVal {
+  if (value instanceof xdr.ScVal) {
+    return value;
+  }
+
+  const encoded = value.toXDR();
+  return xdr.ScVal.fromXDR(
+    typeof encoded === "string" ? Buffer.from(encoded) : Buffer.from(encoded),
+  );
+}
+
+function requireAccountId(accountId: string): void {
+  if (!StrKey.isValidEd25519PublicKey(accountId)) {
+    throw new E.INVALID_ACCOUNT_ID(accountId);
+  }
+}
+
+function requireContractId(contractId: string): void {
+  if (!StrKey.isValidContractId(contractId)) {
+    throw new E.INVALID_CONTRACT_ID(contractId);
+  }
+}
+
+function requireClaimableBalanceId(balanceId: string): void {
+  if (!StrKey.isValidClaimableBalanceId(balanceId)) {
+    throw new E.INVALID_CLAIMABLE_BALANCE_ID(balanceId);
+  }
+}
+
+function requireLiquidityPoolId(liquidityPoolId: string): void {
+  if (!StrKey.isValidLiquidityPoolId(liquidityPoolId)) {
+    throw new E.INVALID_LIQUIDITY_POOL_ID(liquidityPoolId);
+  }
+}
+
+function normalizeHashBytes(hashValue: string | Uint8Array): Buffer {
+  if (typeof hashValue === "string") {
+    if (!HEX_32_BYTE_REGEX.test(hashValue)) {
+      throw new E.INVALID_HEX_HASH(hashValue);
+    }
+    return Buffer.from(hashValue, "hex");
+  }
+
+  if (hashValue.length !== 32) {
+    throw new E.INVALID_HEX_HASH(Buffer.from(hashValue).toString("hex"));
+  }
+
+  return Buffer.from(hashValue);
+}
+
+function normalizeContractDataDurability(
+  durability?: ContractDataDurabilityName,
+): xdr.ContractDataDurability {
+  if (!durability || durability === "persistent") {
+    return xdr.ContractDataDurability.persistent();
+  }
+
+  return xdr.ContractDataDurability.temporary();
+}
+
+function normalizeConfigSettingId(
+  configSettingId: ConfigSettingIdName,
+): xdr.ConfigSettingId {
+  const builder = CONFIG_SETTING_ID_BUILDERS[configSettingId];
+  if (!builder) {
+    throw new E.INVALID_CONFIG_SETTING_ID(configSettingId);
+  }
+
+  return builder();
+}
+
+function normalizeClaimableBalanceId(
+  balanceId: string,
+): xdr.ClaimableBalanceId {
+  const decoded = Buffer.from(StrKey.decodeClaimableBalance(balanceId));
+
+  if (decoded.length !== 33 || decoded[0] !== 0) {
+    throw new E.INVALID_CLAIMABLE_BALANCE_ID(balanceId);
+  }
+
+  return xdr.ClaimableBalanceId.claimableBalanceIdTypeV0(decoded.subarray(1));
+}
+
+function normalizeLedgerKeyHash(
+  args: BuildTtlLedgerKeyArgs,
+): Buffer {
+  if ("key" in args && args.key) {
+    return hash(toRawXdrBuffer(args.key));
+  }
+
+  if (typeof args.keyHash === "string") {
+    try {
+      return Buffer.from(StrKey.decodeSha256Hash(args.keyHash));
+    } catch (_) {
+      throw new E.INVALID_LEDGER_KEY_HASH();
+    }
+  }
+
+  if (args.keyHash.length !== 32) {
+    throw new E.INVALID_LEDGER_KEY_HASH();
+  }
+
+  return Buffer.from(args.keyHash);
+}
+
+/**
+ * Computes the hash used by TTL ledger keys for an existing ledger key.
+ */
+export function hashLedgerKey(key: LedgerKeyLike): Sha256Hash {
+  return StrKey.encodeSha256Hash(hash(toRawXdrBuffer(key)));
+}
+
+/**
+ * Builds an account ledger key branded with the decoded account-entry type.
+ */
+export function buildAccountLedgerKey({
+  accountId,
+}: BuildAccountLedgerKeyArgs): AccountLedgerKey {
+  requireAccountId(accountId);
+
+  return brandLedgerKey<AccountLedgerEntry>(
+    xdr.LedgerKey.account(
+      new xdr.LedgerKeyAccount({
+        accountId: Keypair.fromPublicKey(accountId).xdrAccountId(),
+      }),
+    ),
+  );
+}
+
+/**
+ * Builds a trustline ledger key branded with the decoded trustline-entry type.
+ */
+export function buildTrustlineLedgerKey({
+  accountId,
+  asset,
+}: BuildTrustlineLedgerKeyArgs): TrustlineLedgerKey {
+  requireAccountId(accountId);
+
+  return brandLedgerKey<TrustlineLedgerEntry>(
+    xdr.LedgerKey.trustline(
+      new xdr.LedgerKeyTrustLine({
+        accountId: Keypair.fromPublicKey(accountId).xdrAccountId(),
+        asset: asset.toTrustLineXDRObject() as xdr.TrustLineAsset,
+      }),
+    ),
+  );
+}
+
+/**
+ * Builds an offer ledger key branded with the decoded offer-entry type.
+ */
+export function buildOfferLedgerKey({
+  sellerId,
+  offerId,
+}: BuildOfferLedgerKeyArgs): OfferLedgerKey {
+  requireAccountId(sellerId);
+
+  return brandLedgerKey<OfferLedgerEntry>(
+    xdr.LedgerKey.offer(
+      new xdr.LedgerKeyOffer({
+        sellerId: Keypair.fromPublicKey(sellerId).xdrAccountId(),
+        offerId: xdr.Int64.fromString(String(offerId)),
+      }),
+    ),
+  );
+}
+
+/**
+ * Builds a data-entry ledger key branded with the decoded data-entry type.
+ */
+export function buildDataLedgerKey({
+  accountId,
+  dataName,
+}: BuildDataLedgerKeyArgs): DataLedgerKey {
+  requireAccountId(accountId);
+
+  return brandLedgerKey<DataLedgerEntry>(
+    xdr.LedgerKey.data(
+      new xdr.LedgerKeyData({
+        accountId: Keypair.fromPublicKey(accountId).xdrAccountId(),
+        dataName: typeof dataName === "string" ? dataName : Buffer.from(dataName),
+      }),
+    ),
+  );
+}
+
+/**
+ * Builds a claimable-balance ledger key branded with the decoded entry type.
+ */
+export function buildClaimableBalanceLedgerKey({
+  balanceId,
+}: BuildClaimableBalanceLedgerKeyArgs): ClaimableBalanceLedgerKey {
+  requireClaimableBalanceId(balanceId);
+
+  return brandLedgerKey<ClaimableBalanceLedgerEntry>(
+    xdr.LedgerKey.claimableBalance(
+      new xdr.LedgerKeyClaimableBalance({
+        balanceId: normalizeClaimableBalanceId(balanceId),
+      }),
+    ),
+  );
+}
+
+/**
+ * Builds a liquidity-pool ledger key branded with the decoded entry type.
+ */
+export function buildLiquidityPoolLedgerKey({
+  liquidityPoolId,
+}: BuildLiquidityPoolLedgerKeyArgs): LiquidityPoolLedgerKey {
+  requireLiquidityPoolId(liquidityPoolId);
+
+  return brandLedgerKey<LiquidityPoolLedgerEntry>(
+    xdr.LedgerKey.liquidityPool(
+      new xdr.LedgerKeyLiquidityPool({
+        liquidityPoolId: Buffer.from(
+          StrKey.decodeLiquidityPool(liquidityPoolId),
+        ) as unknown as xdr.PoolId,
+      }),
+    ),
+  );
+}
+
+/**
+ * Builds a generic contract-data ledger key branded with the decoded entry type.
+ */
+export function buildContractDataLedgerKey({
+  contractId,
+  key,
+  durability,
+}: BuildContractDataLedgerKeyArgs): ContractDataLedgerKey {
+  requireContractId(contractId);
+
+  return brandLedgerKey<ContractDataLedgerEntry>(
+    xdr.LedgerKey.contractData(
+      new xdr.LedgerKeyContractData({
+        contract: Address.fromString(contractId).toScAddress(),
+        key: normalizeScVal(key),
+        durability: normalizeContractDataDurability(durability),
+      }),
+    ),
+  );
+}
+
+/**
+ * Builds a contract-instance ledger key branded with the decoded entry type.
+ */
+export function buildContractInstanceLedgerKey({
+  contractId,
+}: BuildContractInstanceLedgerKeyArgs): ContractInstanceLedgerKey {
+  requireContractId(contractId);
+
+  return brandLedgerKey<ContractInstanceLedgerEntry>(
+    new StellarContract(contractId).getFootprint(),
+  );
+}
+
+/**
+ * Builds a contract-code ledger key branded with the decoded entry type.
+ */
+export function buildContractCodeLedgerKey({
+  hash,
+}: BuildContractCodeLedgerKeyArgs): ContractCodeLedgerKey {
+  const hashBytes = normalizeHashBytes(hash);
+
+  return brandLedgerKey<ContractCodeLedgerEntry>(
+    xdr.LedgerKey.contractCode(
+      new xdr.LedgerKeyContractCode({
+        hash: hashBytes,
+      }),
+    ),
+  );
+}
+
+/**
+ * Builds a config-setting ledger key branded with the decoded entry type.
+ */
+export function buildConfigSettingLedgerKey({
+  configSettingId,
+}: BuildConfigSettingLedgerKeyArgs): ConfigSettingLedgerKey {
+  return brandLedgerKey<ConfigSettingLedgerEntry>(
+    xdr.LedgerKey.configSetting(
+      new xdr.LedgerKeyConfigSetting({
+        configSettingId: normalizeConfigSettingId(configSettingId),
+      }),
+    ),
+  );
+}
+
+/**
+ * Builds a TTL ledger key branded with the decoded entry type.
+ */
+export function buildTtlLedgerKey(args: BuildTtlLedgerKeyArgs): TtlLedgerKey {
+  return brandLedgerKey<TtlLedgerEntry>(
+    xdr.LedgerKey.ttl(
+      new xdr.LedgerKeyTtl({
+        keyHash: normalizeLedgerKeyHash(args),
+      }),
+    ),
+  );
+}

--- a/core/ledger-entries/keys.ts
+++ b/core/ledger-entries/keys.ts
@@ -3,6 +3,7 @@ import { Buffer } from "buffer";
 import type { LedgerKeyLike } from "@/common/types/index.ts";
 import { StrKey } from "@/strkeys/index.ts";
 import * as E from "@/ledger-entries/error.ts";
+import { decodeByteFormBase64, toRawXdrBuffer } from "@/ledger-entries/xdr.ts";
 import type {
   AccountLedgerEntry,
   AccountLedgerKey,
@@ -45,8 +46,6 @@ import type {
 import type { Sha256Hash } from "@/strkeys/types.ts";
 
 const HEX_32_BYTE_REGEX = /^[0-9a-f]{64}$/i;
-const BASE64_REGEX =
-  /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
 const CONFIG_SETTING_ID_BUILDERS: Record<
   ConfigSettingIdName,
@@ -89,30 +88,7 @@ const CONFIG_SETTING_ID_BUILDERS: Record<
 function brandLedgerKey<TEntry extends AnyLedgerEntry>(
   key: xdr.LedgerKey,
 ): TypedLedgerKey<TEntry> {
-  return key as TypedLedgerKey<TEntry>;
-}
-
-function toRawXdrBuffer(value: LedgerKeyLike): Buffer {
-  const encoded = value.toXDR("base64");
-  return typeof encoded === "string"
-    ? Buffer.from(encoded, "base64")
-    : Buffer.from(encoded);
-}
-
-function decodeByteFormBase64(value: Uint8Array): string | null {
-  try {
-    const decoded = new TextDecoder("utf-8", { fatal: true }).decode(value);
-    if (
-      BASE64_REGEX.test(decoded) &&
-      Buffer.from(decoded, "base64").toString("base64") === decoded
-    ) {
-      return decoded;
-    }
-  } catch {
-    // Fall through and treat the payload as raw bytes.
-  }
-
-  return null;
+  return key as unknown as TypedLedgerKey<TEntry>;
 }
 
 function normalizeScVal(value: { toXDR(format?: "raw" | "hex" | "base64"): string | Uint8Array }): xdr.ScVal {

--- a/core/ledger-entries/keys.ts
+++ b/core/ledger-entries/keys.ts
@@ -45,6 +45,8 @@ import type {
 import type { Sha256Hash } from "@/strkeys/types.ts";
 
 const HEX_32_BYTE_REGEX = /^[0-9a-f]{64}$/i;
+const BASE64_REGEX =
+  /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
 const CONFIG_SETTING_ID_BUILDERS: Record<
   ConfigSettingIdName,
@@ -97,15 +99,36 @@ function toRawXdrBuffer(value: LedgerKeyLike): Buffer {
     : Buffer.from(encoded);
 }
 
+function decodeByteFormBase64(value: Uint8Array): string | null {
+  try {
+    const decoded = new TextDecoder("utf-8", { fatal: true }).decode(value);
+    if (
+      BASE64_REGEX.test(decoded) &&
+      Buffer.from(decoded, "base64").toString("base64") === decoded
+    ) {
+      return decoded;
+    }
+  } catch {
+    // Fall through and treat the payload as raw bytes.
+  }
+
+  return null;
+}
+
 function normalizeScVal(value: { toXDR(format?: "raw" | "hex" | "base64"): string | Uint8Array }): xdr.ScVal {
   if (value instanceof xdr.ScVal) {
     return value;
   }
 
-  const encoded = value.toXDR();
-  return xdr.ScVal.fromXDR(
-    typeof encoded === "string" ? Buffer.from(encoded) : Buffer.from(encoded),
-  );
+  const encoded = value.toXDR("base64");
+  if (typeof encoded === "string") {
+    return xdr.ScVal.fromXDR(encoded, "base64");
+  }
+
+  const byteFormBase64 = decodeByteFormBase64(encoded);
+  return byteFormBase64
+    ? xdr.ScVal.fromXDR(byteFormBase64, "base64")
+    : xdr.ScVal.fromXDR(Buffer.from(encoded));
 }
 
 function requireAccountId(accountId: string): void {

--- a/core/ledger-entries/keys.unit.test.ts
+++ b/core/ledger-entries/keys.unit.test.ts
@@ -28,20 +28,26 @@ const KNOWN_ISSUE_INVALID_CLAIMABLE_BALANCE_ID =
 
 describe("LedgerEntries key builders", () => {
   it("covers non-default builder branches", () => {
-    const rawBytes = xdr.ScVal.scvU32(7).toXDR();
-    const rawString = Array.from(
-      rawBytes,
-      (byte) => String.fromCharCode(byte),
-    ).join("");
+    const rawBytes = xdr.ScVal.scvU32(7).toXDR("raw");
+    const base64String = xdr.ScVal.scvU32(7).toXDR("base64");
+    const base64Bytes = new TextEncoder().encode(String(base64String));
 
     const temporaryKey = buildContractDataLedgerKey({
       contractId: CONTRACT_ID,
       durability: "temporary",
       key: {
-        toXDR: () => rawString,
+        toXDR: (format?: "raw" | "hex" | "base64") =>
+          format === "base64" ? String(base64String) : rawBytes,
       },
     });
     const bytesKey = buildContractDataLedgerKey({
+      contractId: CONTRACT_ID,
+      key: {
+        toXDR: (format?: "raw" | "hex" | "base64") =>
+          format === "base64" ? base64Bytes : rawBytes,
+      },
+    });
+    const rawFallbackKey = buildContractDataLedgerKey({
       contractId: CONTRACT_ID,
       key: {
         toXDR: () => rawBytes,
@@ -69,6 +75,10 @@ describe("LedgerEntries key builders", () => {
     );
     assertEquals(
       (bytesKey as unknown as xdr.LedgerKey).contractData().key().u32(),
+      7,
+    );
+    assertEquals(
+      (rawFallbackKey as unknown as xdr.LedgerKey).contractData().key().u32(),
       7,
     );
     assertEquals(

--- a/core/ledger-entries/keys.unit.test.ts
+++ b/core/ledger-entries/keys.unit.test.ts
@@ -14,6 +14,12 @@ import {
   buildTtlLedgerKey,
   hashLedgerKey,
 } from "@/ledger-entries/index.ts";
+import type {
+  AccountLedgerEntry,
+  AccountLedgerKey,
+  AnyLedgerEntry,
+  EntryFromLedgerKey,
+} from "@/ledger-entries/types.ts";
 import { StrKey } from "@/strkeys/index.ts";
 import type {
   ClaimableBalanceId,
@@ -25,6 +31,17 @@ const ACCOUNT_ID = Keypair.random().publicKey() as Ed25519PublicKey;
 const CONTRACT_ID = StrKey.encodeContract(Buffer.alloc(32, 3)) as ContractId;
 const KNOWN_ISSUE_INVALID_CLAIMABLE_BALANCE_ID =
   "BAAT6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGXACA" as ClaimableBalanceId;
+
+type Assert<T extends true> = T;
+type IsEqual<A, B> = (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type _TypedAccountKeyInfersEntry = Assert<
+  IsEqual<EntryFromLedgerKey<AccountLedgerKey>, AccountLedgerEntry>
+>;
+type _UnbrandedLedgerKeyFallsBackToUnion = Assert<
+  IsEqual<EntryFromLedgerKey<xdr.LedgerKey>, AnyLedgerEntry>
+>;
 
 describe("LedgerEntries key builders", () => {
   it("covers non-default builder branches", () => {
@@ -158,6 +175,27 @@ describe("LedgerEntries key builders", () => {
     }) as unknown as xdr.LedgerKey & LedgerKeyLike;
     Object.defineProperty(key, "toXDR", {
       value: () => new Uint8Array([1, 2, 3, 4]),
+    });
+
+    const hash = hashLedgerKey(key);
+
+    assertEquals(StrKey.isSha256Hash(hash), true);
+  });
+
+  it("hashes ledger keys whose base64 serialization returns bytes", () => {
+    const key = buildAccountLedgerKey({
+      accountId: ACCOUNT_ID,
+    }) as unknown as xdr.LedgerKey & LedgerKeyLike;
+    const originalToXdr = key.toXDR.bind(key);
+
+    Object.defineProperty(key, "toXDR", {
+      value: (format?: "raw" | "hex" | "base64") => {
+        if (format === "base64") {
+          return new TextEncoder().encode(String(originalToXdr("base64")));
+        }
+
+        return originalToXdr(format ?? "raw");
+      },
     });
 
     const hash = hashLedgerKey(key);

--- a/core/ledger-entries/keys.unit.test.ts
+++ b/core/ledger-entries/keys.unit.test.ts
@@ -1,0 +1,157 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { Buffer } from "buffer";
+import { Keypair, xdr } from "stellar-sdk";
+import type { LedgerKeyLike } from "@/common/types/index.ts";
+import * as E from "@/ledger-entries/error.ts";
+import {
+  buildAccountLedgerKey,
+  buildClaimableBalanceLedgerKey,
+  buildConfigSettingLedgerKey,
+  buildContractCodeLedgerKey,
+  buildContractDataLedgerKey,
+  buildDataLedgerKey,
+  buildTtlLedgerKey,
+  hashLedgerKey,
+} from "@/ledger-entries/index.ts";
+import { StrKey } from "@/strkeys/index.ts";
+import type {
+  ClaimableBalanceId,
+  ContractId,
+  Ed25519PublicKey,
+} from "@/strkeys/types.ts";
+
+const ACCOUNT_ID = Keypair.random().publicKey() as Ed25519PublicKey;
+const CONTRACT_ID = StrKey.encodeContract(Buffer.alloc(32, 3)) as ContractId;
+const KNOWN_ISSUE_INVALID_CLAIMABLE_BALANCE_ID =
+  "BAAT6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGXACA" as ClaimableBalanceId;
+
+describe("LedgerEntries key builders", () => {
+  it("covers non-default builder branches", () => {
+    const rawBytes = xdr.ScVal.scvU32(7).toXDR();
+    const rawString = Array.from(
+      rawBytes,
+      (byte) => String.fromCharCode(byte),
+    ).join("");
+
+    const temporaryKey = buildContractDataLedgerKey({
+      contractId: CONTRACT_ID,
+      durability: "temporary",
+      key: {
+        toXDR: () => rawString,
+      },
+    });
+    const bytesKey = buildContractDataLedgerKey({
+      contractId: CONTRACT_ID,
+      key: {
+        toXDR: () => rawBytes,
+      },
+    });
+    const dataKey = buildDataLedgerKey({
+      accountId: ACCOUNT_ID,
+      dataName: new Uint8Array([1, 2, 3]),
+    });
+    const codeKey = buildContractCodeLedgerKey({
+      hash: new Uint8Array(32).fill(5),
+    });
+    const ttlKey = buildTtlLedgerKey({
+      keyHash: new Uint8Array(32).fill(6),
+    });
+
+    assertEquals(
+      (temporaryKey as unknown as xdr.LedgerKey).contractData().durability()
+        .name,
+      "temporary",
+    );
+    assertEquals(
+      (temporaryKey as unknown as xdr.LedgerKey).contractData().key().u32(),
+      7,
+    );
+    assertEquals(
+      (bytesKey as unknown as xdr.LedgerKey).contractData().key().u32(),
+      7,
+    );
+    assertEquals(
+      Buffer.from((dataKey as unknown as xdr.LedgerKey).data().dataName()),
+      Buffer.from([1, 2, 3]),
+    );
+    assertEquals(
+      (codeKey as unknown as xdr.LedgerKey).contractCode().hash().length,
+      32,
+    );
+    assertEquals(
+      (ttlKey as unknown as xdr.LedgerKey).ttl().keyHash().length,
+      32,
+    );
+  });
+
+  it("validates claimable balance, config setting, and hash inputs", () => {
+    const originalDecodeClaimableBalance = StrKey.decodeClaimableBalance;
+    try {
+      StrKey.decodeClaimableBalance = () =>
+        new Uint8Array([0]) as ReturnType<
+          typeof StrKey.decodeClaimableBalance
+        >;
+
+      assertThrows(
+        () =>
+          buildClaimableBalanceLedgerKey({
+            balanceId: KNOWN_ISSUE_INVALID_CLAIMABLE_BALANCE_ID,
+          }),
+        E.INVALID_CLAIMABLE_BALANCE_ID,
+      );
+    } finally {
+      StrKey.decodeClaimableBalance = originalDecodeClaimableBalance;
+    }
+
+    assertThrows(
+      () =>
+        buildContractDataLedgerKey({
+          contractId: "BAD" as ContractId,
+          key: xdr.ScVal.scvU32(1),
+        }),
+      E.INVALID_CONTRACT_ID,
+    );
+    assertThrows(
+      () =>
+        buildConfigSettingLedgerKey({
+          configSettingId: "badSetting" as never,
+        }),
+      E.INVALID_CONFIG_SETTING_ID,
+    );
+    assertThrows(
+      () =>
+        buildContractCodeLedgerKey({
+          hash: new Uint8Array(31),
+        }),
+      E.INVALID_HEX_HASH,
+    );
+    assertThrows(
+      () =>
+        buildTtlLedgerKey({
+          keyHash: "BAD" as never,
+        }),
+      E.INVALID_LEDGER_KEY_HASH,
+    );
+    assertThrows(
+      () =>
+        buildTtlLedgerKey({
+          keyHash: new Uint8Array(31),
+        }),
+      E.INVALID_LEDGER_KEY_HASH,
+    );
+  });
+
+  it("hashes ledger keys that serialize to raw bytes", () => {
+    const key = buildAccountLedgerKey({
+      accountId: ACCOUNT_ID,
+    }) as unknown as xdr.LedgerKey & LedgerKeyLike;
+    Object.defineProperty(key, "toXDR", {
+      value: () => new Uint8Array([1, 2, 3, 4]),
+    });
+
+    const hash = hashLedgerKey(key);
+
+    assertEquals(StrKey.isSha256Hash(hash), true);
+  });
+});

--- a/core/ledger-entries/types.ts
+++ b/core/ledger-entries/types.ts
@@ -355,7 +355,9 @@ export type ContractExecutableView =
 export type ConfigSettingValue =
   | number
   | bigint[]
-  | unknown;
+  | readonly { toBigInt(): bigint }[]
+  | readonly XdrSerializable[]
+  | XdrSerializable;
 
 /**
  * Shared metadata preserved on all decoded ledger-entry results.
@@ -553,7 +555,7 @@ export declare const LEDGER_KEY_BRAND: unique symbol;
  * At runtime this is still a plain Stellar SDK ledger-key object.
  */
 export type TypedLedgerKey<TEntry extends AnyLedgerEntry> = LedgerKeyLike & {
-  readonly [LEDGER_KEY_BRAND]?: TEntry;
+  readonly [LEDGER_KEY_BRAND]: TEntry;
 };
 
 /** Typed account ledger key. */

--- a/core/ledger-entries/types.ts
+++ b/core/ledger-entries/types.ts
@@ -1,0 +1,604 @@
+import type {
+  BinaryData,
+  LedgerKeyLike,
+  ScValLike,
+  TrustlineAssetLike,
+  XdrSerializable,
+} from "@/common/types/index.ts";
+import type { ScValParsed } from "@/common/helpers/xdr/types.ts";
+import type { ChangeTrustAssetString } from "@/common/helpers/xdr/parse-change-trust-asset.ts";
+import type { StellarAssetCanonicalString } from "@/asset/sep11/types.ts";
+import type { NetworkConfig } from "@/network/index.ts";
+import type {
+  ClaimableBalanceId,
+  ContractId,
+  Ed25519PublicKey,
+  LiquidityPoolId,
+  PreAuthTx,
+  Sha256Hash,
+  SignedPayload,
+} from "@/strkeys/types.ts";
+
+/**
+ * Constructor arguments accepted by {@link LedgerEntries}.
+ */
+export type LedgerEntriesConstructorArgs =
+  | {
+    networkConfig: NetworkConfig;
+    rpc?: never;
+  }
+  | {
+    rpc: RpcLedgerEntriesClient;
+    networkConfig?: never;
+  };
+
+/**
+ * Friendly durability names accepted by contract-data helpers.
+ */
+export type ContractDataDurabilityName = "persistent" | "temporary";
+
+/**
+ * Public config-setting identifiers accepted by config-setting helpers.
+ */
+export type ConfigSettingIdName =
+  | "configSettingContractMaxSizeBytes"
+  | "configSettingContractComputeV0"
+  | "configSettingContractLedgerCostV0"
+  | "configSettingContractHistoricalDataV0"
+  | "configSettingContractEventsV0"
+  | "configSettingContractBandwidthV0"
+  | "configSettingContractCostParamsCpuInstructions"
+  | "configSettingContractCostParamsMemoryBytes"
+  | "configSettingContractDataKeySizeBytes"
+  | "configSettingContractDataEntrySizeBytes"
+  | "configSettingStateArchival"
+  | "configSettingContractExecutionLanes"
+  | "configSettingLiveSorobanStateSizeWindow"
+  | "configSettingEvictionIterator"
+  | "configSettingContractParallelComputeV0"
+  | "configSettingContractLedgerCostExtV0"
+  | "configSettingScpTiming";
+
+/**
+ * Arguments for building an account ledger key.
+ */
+export type BuildAccountLedgerKeyArgs = {
+  accountId: Ed25519PublicKey;
+};
+
+/**
+ * Arguments for building a trustline ledger key.
+ */
+export type BuildTrustlineLedgerKeyArgs = {
+  accountId: Ed25519PublicKey;
+  asset: TrustlineAssetLike;
+};
+
+/**
+ * Arguments for building an offer ledger key.
+ */
+export type BuildOfferLedgerKeyArgs = {
+  sellerId: Ed25519PublicKey;
+  offerId: bigint | number | string;
+};
+
+/**
+ * Arguments for building a manage-data ledger key.
+ */
+export type BuildDataLedgerKeyArgs = {
+  accountId: Ed25519PublicKey;
+  dataName: string | BinaryData;
+};
+
+/**
+ * Arguments for building a claimable-balance ledger key.
+ */
+export type BuildClaimableBalanceLedgerKeyArgs = {
+  balanceId: ClaimableBalanceId;
+};
+
+/**
+ * Arguments for building a liquidity-pool ledger key.
+ */
+export type BuildLiquidityPoolLedgerKeyArgs = {
+  liquidityPoolId: LiquidityPoolId;
+};
+
+/**
+ * Arguments for building a generic contract-data ledger key.
+ */
+export type BuildContractDataLedgerKeyArgs = {
+  contractId: ContractId;
+  key: ScValLike;
+  durability?: ContractDataDurabilityName;
+};
+
+/**
+ * Arguments for building a contract-instance ledger key.
+ */
+export type BuildContractInstanceLedgerKeyArgs = {
+  contractId: ContractId;
+};
+
+/**
+ * Arguments for building a contract-code ledger key.
+ */
+export type BuildContractCodeLedgerKeyArgs = {
+  hash: string | BinaryData;
+};
+
+/**
+ * Arguments for building a config-setting ledger key.
+ */
+export type BuildConfigSettingLedgerKeyArgs = {
+  configSettingId: ConfigSettingIdName;
+};
+
+/**
+ * Arguments for building a TTL ledger key.
+ */
+export type BuildTtlLedgerKeyArgs =
+  | {
+    key: LedgerKeyLike;
+    keyHash?: never;
+  }
+  | {
+    key?: never;
+    keyHash: Sha256Hash | BinaryData;
+  };
+
+/**
+ * Arguments accepted by {@link LedgerEntries.contractCode}.
+ */
+export type ContractCodeLookupArgs =
+  | BuildContractCodeLedgerKeyArgs
+  | {
+    contractId: ContractId;
+  };
+
+/**
+ * Minimal XDR union surface preserved on decoded ledger entries.
+ */
+export type LedgerEntryValueXdr = XdrSerializable & {
+  switch(): { name: string; value: number };
+};
+
+/**
+ * The parsed RPC entry preserved on all decoded results.
+ */
+export type LedgerEntryXdr = {
+  key: LedgerKeyLike;
+  val: LedgerEntryValueXdr;
+  lastModifiedLedgerSeq?: number;
+  liveUntilLedgerSeq?: number;
+};
+
+/**
+ * Minimal getLedgerEntries response returned by supported RPC clients.
+ */
+export type RpcLedgerEntriesResponse = {
+  entries: LedgerEntryXdr[];
+  latestLedger: number;
+};
+
+/**
+ * Minimal RPC client contract required by {@link LedgerEntries}.
+ */
+export interface RpcLedgerEntriesClient {
+  /**
+   * Fetches one or more live ledger entries by key.
+   */
+  getLedgerEntries(...keys: LedgerKeyLike[]): Promise<RpcLedgerEntriesResponse>;
+}
+
+/**
+ * Logical entry types returned by the ledger-entries module.
+ */
+export type LedgerEntryKind =
+  | "account"
+  | "trustline"
+  | "offer"
+  | "data"
+  | "claimableBalance"
+  | "liquidityPool"
+  | "contractData"
+  | "contractInstance"
+  | "contractCode"
+  | "configSetting"
+  | "ttl";
+
+/**
+ * Friendly account flag view.
+ */
+export type AccountFlagsView = {
+  value: number;
+  authRequired: boolean;
+  authRevocable: boolean;
+  authImmutable: boolean;
+  authClawbackEnabled: boolean;
+};
+
+/**
+ * Friendly trustline flag view.
+ */
+export type TrustlineFlagsView = {
+  value: number;
+  authorized: boolean;
+  authorizedToMaintainLiabilities: boolean;
+  clawbackEnabled: boolean;
+};
+
+/**
+ * Friendly offer flag view.
+ */
+export type OfferFlagsView = {
+  value: number;
+  passive: boolean;
+};
+
+/**
+ * Friendly claimable-balance flag view.
+ */
+export type ClaimableBalanceFlagsView = {
+  value: number;
+  clawbackEnabled: boolean;
+};
+
+/**
+ * Friendly liability view reused by trustlines and offers.
+ */
+export type LiabilitiesView = {
+  buying: bigint;
+  selling: bigint;
+};
+
+/**
+ * Friendly signer-key view.
+ */
+export type SignerKeyView =
+  | {
+    type: "ed25519";
+    value: Ed25519PublicKey;
+  }
+  | {
+    type: "preAuthTx";
+    value: PreAuthTx;
+  }
+  | {
+    type: "hashX";
+    value: Sha256Hash;
+  }
+  | {
+    type: "ed25519SignedPayload";
+    value: SignedPayload;
+    ed25519PublicKey: Ed25519PublicKey;
+    payload: Uint8Array;
+  };
+
+/**
+ * Friendly signer view returned on account entries.
+ */
+export type LedgerEntrySigner = {
+  key: SignerKeyView;
+  weight: number;
+};
+
+/**
+ * Friendly threshold view returned on account entries.
+ */
+export type AccountThresholds = {
+  masterWeight: number;
+  low: number;
+  medium: number;
+  high: number;
+};
+
+/**
+ * Friendly offer price view.
+ */
+export type OfferPrice = {
+  n: number;
+  d: number;
+};
+
+/**
+ * Friendly claim-predicate view.
+ */
+export type ClaimPredicateView =
+  | {
+    type: "unconditional";
+  }
+  | {
+    type: "and";
+    predicates: ClaimPredicateView[];
+  }
+  | {
+    type: "or";
+    predicates: ClaimPredicateView[];
+  }
+  | {
+    type: "not";
+    predicate: ClaimPredicateView | null;
+  }
+  | {
+    type: "beforeAbsoluteTime";
+    unixSeconds: bigint;
+  }
+  | {
+    type: "beforeRelativeTime";
+    seconds: bigint;
+  };
+
+/**
+ * Friendly claimable-balance claimant view.
+ */
+export type ClaimantView = {
+  destination: Ed25519PublicKey;
+  predicate: ClaimPredicateView;
+};
+
+/**
+ * Friendly contract executable view.
+ */
+export type ContractExecutableView =
+  | {
+    type: "wasm";
+    wasmHash: string;
+  }
+  | {
+    type: "stellarAsset";
+  };
+
+/**
+ * Value exposed by config-setting reads.
+ */
+export type ConfigSettingValue =
+  | number
+  | bigint[]
+  | unknown;
+
+/**
+ * Shared metadata preserved on all decoded ledger-entry results.
+ */
+export type BaseLedgerEntry = {
+  type: LedgerEntryKind;
+  xdr: LedgerEntryXdr;
+  lastModifiedLedgerSeq?: number;
+  liveUntilLedgerSeq?: number;
+};
+
+/**
+ * Shared metadata preserved on a specific decoded ledger-entry result.
+ */
+export type BaseLedgerEntryOf<TKind extends LedgerEntryKind> =
+  Omit<BaseLedgerEntry, "type"> & {
+    type: TKind;
+  };
+
+/**
+ * Friendly account-entry result.
+ */
+export type AccountLedgerEntry = BaseLedgerEntry & {
+  type: "account";
+  accountId: Ed25519PublicKey;
+  balance: bigint;
+  sequenceNumber: bigint;
+  numSubEntries: number;
+  inflationDestination?: Ed25519PublicKey;
+  flags: AccountFlagsView;
+  homeDomain: string;
+  thresholds: AccountThresholds;
+  signers: LedgerEntrySigner[];
+};
+
+/**
+ * Friendly trustline-entry result.
+ */
+export type TrustlineLedgerEntry = BaseLedgerEntry & {
+  type: "trustline";
+  accountId: Ed25519PublicKey;
+  asset: ChangeTrustAssetString;
+  balance: bigint;
+  limit: bigint;
+  flags: TrustlineFlagsView;
+  liabilities?: LiabilitiesView;
+};
+
+/**
+ * Friendly offer-entry result.
+ */
+export type OfferLedgerEntry = BaseLedgerEntry & {
+  type: "offer";
+  sellerId: Ed25519PublicKey;
+  offerId: bigint;
+  selling: StellarAssetCanonicalString;
+  buying: StellarAssetCanonicalString;
+  amount: bigint;
+  price: OfferPrice;
+  flags: OfferFlagsView;
+};
+
+/**
+ * Friendly manage-data-entry result.
+ */
+export type DataLedgerEntry = BaseLedgerEntry & {
+  type: "data";
+  accountId: Ed25519PublicKey;
+  dataName: string;
+  dataValue: Uint8Array;
+};
+
+/**
+ * Friendly claimable-balance-entry result.
+ */
+export type ClaimableBalanceLedgerEntry = BaseLedgerEntry & {
+  type: "claimableBalance";
+  balanceId: ClaimableBalanceId;
+  claimants: ClaimantView[];
+  asset: StellarAssetCanonicalString;
+  amount: bigint;
+  flags: ClaimableBalanceFlagsView;
+};
+
+/**
+ * Friendly liquidity-pool-entry result.
+ */
+export type LiquidityPoolLedgerEntry = BaseLedgerEntry & {
+  type: "liquidityPool";
+  liquidityPoolId: LiquidityPoolId;
+  poolType: "liquidityPoolConstantProduct";
+  assetA: StellarAssetCanonicalString;
+  assetB: StellarAssetCanonicalString;
+  fee: number;
+  reserveA: bigint;
+  reserveB: bigint;
+  totalPoolShares: bigint;
+  poolSharesTrustLineCount: bigint;
+};
+
+/**
+ * Friendly generic contract-data-entry result.
+ */
+export type ContractDataLedgerEntry = BaseLedgerEntry & {
+  type: "contractData";
+  contractId: ContractId;
+  durability: ContractDataDurabilityName;
+  keyScVal: ScValLike;
+  valueScVal: ScValLike;
+  key: ScValParsed;
+  value: ScValParsed;
+};
+
+/**
+ * Friendly contract-instance-entry result.
+ */
+export type ContractInstanceLedgerEntry = BaseLedgerEntry & {
+  type: "contractInstance";
+  contractId: ContractId;
+  durability: ContractDataDurabilityName;
+  keyScVal: ScValLike;
+  valueScVal: ScValLike;
+  executable: ContractExecutableView;
+  storage: ScValParsed;
+};
+
+/**
+ * Friendly contract-code cost input view.
+ */
+export type ContractCodeCostInputsView = {
+  nInstructions: number;
+  nFunctions: number;
+  nGlobals: number;
+  nTableEntries: number;
+  nTypes: number;
+  nDataSegments: number;
+  nElemSegments: number;
+  nImports: number;
+  nExports: number;
+  nDataSegmentBytes: number;
+};
+
+/**
+ * Friendly contract-code-entry result.
+ */
+export type ContractCodeLedgerEntry = BaseLedgerEntry & {
+  type: "contractCode";
+  hash: string;
+  code: Uint8Array;
+  costInputs?: ContractCodeCostInputsView;
+};
+
+/**
+ * Friendly config-setting-entry result.
+ */
+export type ConfigSettingLedgerEntry = BaseLedgerEntry & {
+  type: "configSetting";
+  configSettingId: ConfigSettingIdName;
+  value: ConfigSettingValue;
+};
+
+/**
+ * Friendly TTL-entry result.
+ */
+export type TtlLedgerEntry = BaseLedgerEntry & {
+  type: "ttl";
+  keyHash: Sha256Hash;
+  expiresAtLedger: number;
+};
+
+/**
+ * Any decoded ledger-entry result returned by this module.
+ */
+export type AnyLedgerEntry =
+  | AccountLedgerEntry
+  | TrustlineLedgerEntry
+  | OfferLedgerEntry
+  | DataLedgerEntry
+  | ClaimableBalanceLedgerEntry
+  | LiquidityPoolLedgerEntry
+  | ContractDataLedgerEntry
+  | ContractInstanceLedgerEntry
+  | ContractCodeLedgerEntry
+  | ConfigSettingLedgerEntry
+  | TtlLedgerEntry;
+
+/**
+ * Compile-time brand used to associate builder-produced keys with entry types.
+ */
+export declare const LEDGER_KEY_BRAND: unique symbol;
+
+/**
+ * Compile-time branded ledger key that preserves the decoded entry type.
+ *
+ * At runtime this is still a plain Stellar SDK ledger-key object.
+ */
+export type TypedLedgerKey<TEntry extends AnyLedgerEntry> = LedgerKeyLike & {
+  readonly [LEDGER_KEY_BRAND]?: TEntry;
+};
+
+/** Typed account ledger key. */
+export type AccountLedgerKey = TypedLedgerKey<AccountLedgerEntry>;
+/** Typed trustline ledger key. */
+export type TrustlineLedgerKey = TypedLedgerKey<TrustlineLedgerEntry>;
+/** Typed offer ledger key. */
+export type OfferLedgerKey = TypedLedgerKey<OfferLedgerEntry>;
+/** Typed data ledger key. */
+export type DataLedgerKey = TypedLedgerKey<DataLedgerEntry>;
+/** Typed claimable-balance ledger key. */
+export type ClaimableBalanceLedgerKey =
+  TypedLedgerKey<ClaimableBalanceLedgerEntry>;
+/** Typed liquidity-pool ledger key. */
+export type LiquidityPoolLedgerKey = TypedLedgerKey<LiquidityPoolLedgerEntry>;
+/** Typed contract-data ledger key. */
+export type ContractDataLedgerKey = TypedLedgerKey<ContractDataLedgerEntry>;
+/** Typed contract-instance ledger key. */
+export type ContractInstanceLedgerKey =
+  TypedLedgerKey<ContractInstanceLedgerEntry>;
+/** Typed contract-code ledger key. */
+export type ContractCodeLedgerKey = TypedLedgerKey<ContractCodeLedgerEntry>;
+/** Typed config-setting ledger key. */
+export type ConfigSettingLedgerKey = TypedLedgerKey<ConfigSettingLedgerEntry>;
+/** Typed TTL ledger key. */
+export type TtlLedgerKey = TypedLedgerKey<TtlLedgerEntry>;
+
+/**
+ * Any branded ledger key emitted by the public builder helpers.
+ */
+export type AnyTypedLedgerKey =
+  | AccountLedgerKey
+  | TrustlineLedgerKey
+  | OfferLedgerKey
+  | DataLedgerKey
+  | ClaimableBalanceLedgerKey
+  | LiquidityPoolLedgerKey
+  | ContractDataLedgerKey
+  | ContractInstanceLedgerKey
+  | ContractCodeLedgerKey
+  | ConfigSettingLedgerKey
+  | TtlLedgerKey;
+
+/**
+ * Infers the decoded entry type for a ledger key produced by a builder helper.
+ */
+export type EntryFromLedgerKey<TKey extends LedgerKeyLike> =
+  TKey extends TypedLedgerKey<infer TEntry> ? TEntry : AnyLedgerEntry;

--- a/core/ledger-entries/xdr.ts
+++ b/core/ledger-entries/xdr.ts
@@ -1,0 +1,43 @@
+import { Buffer } from "buffer";
+import type { XdrSerializable } from "@/common/types/index.ts";
+
+const BASE64_REGEX =
+  /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+export function decodeByteFormBase64(value: Uint8Array): string | null {
+  try {
+    const decoded = new TextDecoder("utf-8", { fatal: true }).decode(value);
+    if (
+      BASE64_REGEX.test(decoded) &&
+      Buffer.from(decoded, "base64").toString("base64") === decoded
+    ) {
+      return decoded;
+    }
+  } catch {
+    // Fall through and treat the payload as raw bytes.
+  }
+
+  return null;
+}
+
+export function toBase64Xdr(value: XdrSerializable): string {
+  const encoded = value.toXDR("base64");
+  if (typeof encoded === "string") {
+    return encoded;
+  }
+
+  const byteFormBase64 = decodeByteFormBase64(encoded);
+  return byteFormBase64 ?? Buffer.from(encoded).toString("base64");
+}
+
+export function toRawXdrBuffer(value: XdrSerializable): Buffer {
+  const encoded = value.toXDR("base64");
+  if (typeof encoded === "string") {
+    return Buffer.from(encoded, "base64");
+  }
+
+  const byteFormBase64 = decodeByteFormBase64(encoded);
+  return byteFormBase64
+    ? Buffer.from(byteFormBase64, "base64")
+    : Buffer.from(encoded);
+}

--- a/core/ledger-parser/error.ts
+++ b/core/ledger-parser/error.ts
@@ -70,6 +70,8 @@ export enum Code {
   INVALID_TRANSACTION_INDEX = "LDP_005",
   INVALID_OPERATION_INDEX = "LDP_006",
   UNSUPPORTED_OPERATION_TYPE = "LDP_007",
+  MISSING_TRANSACTION_ENVELOPE = "LDP_008",
+  UNSUPPORTED_ENVELOPE_TYPE = "LDP_009",
 }
 
 /**
@@ -216,6 +218,48 @@ export class UNSUPPORTED_OPERATION_TYPE extends LedgerParserError {
 }
 
 /**
+ * Thrown when envelope-dependent transaction data is requested but unavailable.
+ */
+export class MISSING_TRANSACTION_ENVELOPE extends LedgerParserError {
+  /**
+   * Creates the error.
+   *
+   * @param hash Transaction hash lacking an envelope.
+   * @param property Envelope-dependent property that was requested.
+   */
+  constructor(hash: string, property: string) {
+    super({
+      code: Code.MISSING_TRANSACTION_ENVELOPE,
+      message:
+        `Cannot get ${property} for transaction ${hash} - envelope not available`,
+      details:
+        "The requested transaction property depends on an envelope, but the transaction metadata did not include one.",
+      data: { hash, property },
+    });
+  }
+}
+
+/**
+ * Thrown when a transaction envelope type is not supported by the parser.
+ */
+export class UNSUPPORTED_ENVELOPE_TYPE extends LedgerParserError {
+  /**
+   * Creates the error.
+   *
+   * @param envelopeType Unsupported transaction-envelope discriminator.
+   */
+  constructor(envelopeType: string | number) {
+    super({
+      code: Code.UNSUPPORTED_ENVELOPE_TYPE,
+      message: `Unsupported envelope type: ${envelopeType}`,
+      details:
+        "The transaction parser encountered an envelope type it does not know how to decode.",
+      data: { envelopeType },
+    });
+  }
+}
+
+/**
  * Export all error classes for convenience.
  */
 export const ERROR_LDP = {
@@ -227,4 +271,6 @@ export const ERROR_LDP = {
   [Code.INVALID_TRANSACTION_INDEX]: INVALID_TRANSACTION_INDEX,
   [Code.INVALID_OPERATION_INDEX]: INVALID_OPERATION_INDEX,
   [Code.UNSUPPORTED_OPERATION_TYPE]: UNSUPPORTED_OPERATION_TYPE,
+  [Code.MISSING_TRANSACTION_ENVELOPE]: MISSING_TRANSACTION_ENVELOPE,
+  [Code.UNSUPPORTED_ENVELOPE_TYPE]: UNSUPPORTED_ENVELOPE_TYPE,
 };

--- a/core/ledger-parser/transaction/index.ts
+++ b/core/ledger-parser/transaction/index.ts
@@ -12,7 +12,11 @@ import {
   parseMuxedAccount,
 } from "@/common/helpers/xdr/index.ts";
 import { Operation } from "@/ledger-parser/operation/index.ts";
-import { INVALID_TRANSACTION_INDEX } from "@/ledger-parser/error.ts";
+import {
+  INVALID_TRANSACTION_INDEX,
+  MISSING_TRANSACTION_ENVELOPE,
+  UNSUPPORTED_ENVELOPE_TYPE,
+} from "@/ledger-parser/error.ts";
 import type { Ledger } from "@/ledger-parser/ledger/index.ts";
 import { isDefined } from "@/common/type-guards/is-defined.ts";
 
@@ -180,9 +184,7 @@ export class Transaction {
   @memoize()
   get sourceAccount(): string {
     if (!this.txEnvelope) {
-      throw new Error(
-        `Cannot get source account for transaction ${this.hash} - envelope not available`,
-      );
+      throw new MISSING_TRANSACTION_ENVELOPE(this.hash, "source account");
     }
 
     const envelope = this.envelope;
@@ -208,7 +210,7 @@ export class Transaction {
       return parseMuxedAccount(feeBump.feeSource());
     }
 
-    throw new Error(`Unsupported envelope type: ${envType}`);
+    throw new UNSUPPORTED_ENVELOPE_TYPE(envType);
   }
 
   /**
@@ -228,9 +230,7 @@ export class Transaction {
   @memoize()
   get sequence(): bigint {
     if (!this.txEnvelope) {
-      throw new Error(
-        `Cannot get sequence for transaction ${this.hash} - envelope not available`,
-      );
+      throw new MISSING_TRANSACTION_ENVELOPE(this.hash, "sequence");
     }
 
     const envelope = this.envelope;
@@ -260,9 +260,7 @@ export class Transaction {
   @memoize()
   get operations(): Operation[] {
     if (!this.txEnvelope) {
-      throw new Error(
-        `Cannot get operations for transaction ${this.hash} - envelope not available`,
-      );
+      throw new MISSING_TRANSACTION_ENVELOPE(this.hash, "operations");
     }
 
     const envelope = this.envelope;

--- a/core/mod.ts
+++ b/core/mod.ts
@@ -27,6 +27,10 @@ export * from "@/ledger-parser/index.ts";
 /** Error constructors for ledger parser helpers. */
 export * as ERRORS_LDP from "@/ledger-parser/error.ts";
 
+export * from "@/ledger-entries/index.ts";
+/** Error constructors for ledger entry access helpers. */
+export * as ERRORS_LDE from "@/ledger-entries/error.ts";
+
 export * from "@/network/index.ts";
 export * from "@/network/types.ts";
 

--- a/core/network/error.ts
+++ b/core/network/error.ts
@@ -1,0 +1,72 @@
+import { ColibriError } from "@/error/index.ts";
+
+export type Meta = {
+  cause: Error | null;
+  data: unknown;
+};
+
+export abstract class NetworkError<
+  CodeType extends string,
+> extends ColibriError<CodeType, Meta> {
+  override readonly source = "@colibri/core/network";
+  override readonly meta: Meta;
+
+  constructor(args: {
+    code: CodeType;
+    message: string;
+    details: string;
+    data: unknown;
+    cause?: Error;
+  }) {
+    const meta = {
+      cause: args.cause ?? null,
+      data: args.data,
+    };
+
+    super({
+      domain: "core",
+      source: "@colibri/core/network",
+      code: args.code,
+      message: args.message,
+      details: args.details,
+      meta,
+    });
+
+    this.meta = meta;
+  }
+}
+
+export enum Code {
+  PROPERTY_NOT_SET = "NET_001",
+  PROPERTY_ALREADY_SET = "NET_002",
+}
+
+export class PROPERTY_NOT_SET extends NetworkError<Code> {
+  constructor(property: string) {
+    super({
+      code: Code.PROPERTY_NOT_SET,
+      message: `Property ${property} is not set in the Network Config instance`,
+      details:
+        "The requested NetworkConfig property was accessed before it was initialized.",
+      data: { property },
+    });
+  }
+}
+
+export class PROPERTY_ALREADY_SET extends NetworkError<Code> {
+  constructor(property: string) {
+    super({
+      code: Code.PROPERTY_ALREADY_SET,
+      message:
+        `Property ${property} is already set in the Network Config instance`,
+      details:
+        "The requested NetworkConfig property can only be set once for a given configuration instance.",
+      data: { property },
+    });
+  }
+}
+
+export const ERROR_NET = {
+  [Code.PROPERTY_NOT_SET]: PROPERTY_NOT_SET,
+  [Code.PROPERTY_ALREADY_SET]: PROPERTY_ALREADY_SET,
+};

--- a/core/network/index.ts
+++ b/core/network/index.ts
@@ -10,6 +10,7 @@ import type {
   TestNetNetCustomConfig,
 } from "@/network/types.ts";
 import { isDefined } from "@/common/type-guards/is-defined.ts";
+import * as E from "@/network/error.ts";
 
 /** Preset provider helpers for commonly used public Stellar RPC networks. */
 export * as NetworkProviders from "@/network/providers/index.ts";
@@ -198,9 +199,7 @@ export class NetworkConfig implements INetworkConfig {
       | "_allowHttp"
   ): NetworkType | string | boolean {
     if (isDefined(this[arg])) return this[arg];
-    throw new Error(
-      `Property ${arg} is not set in the Network Config instance`
-    );
+    throw new E.PROPERTY_NOT_SET(arg);
   }
 
   /** @internal */
@@ -215,9 +214,7 @@ export class NetworkConfig implements INetworkConfig {
       | "_allowHttp"
   ): void {
     if (isDefined(this[arg])) {
-      throw new Error(
-        `Property ${arg} is already set in the Network Config instance`
-      );
+      throw new E.PROPERTY_ALREADY_SET(arg);
     }
   }
 

--- a/core/strkeys/index.ts
+++ b/core/strkeys/index.ts
@@ -200,23 +200,35 @@ function isValidClaimableBalanceId(value: string): value is ClaimableBalanceId {
 }
 
 const stellarSdkStr = {
-  encodeContract: StellarSdkStrKey.encodeContract,
+  encodeContract: ((...args: Parameters<typeof StellarSdkStrKey.encodeContract>) =>
+    StellarSdkStrKey.encodeContract(...args) as ContractId),
   decodeContract: StellarSdkStrKey.decodeContract,
-  encodePreAuthTx: StellarSdkStrKey.encodePreAuthTx,
+  encodePreAuthTx: ((...args: Parameters<typeof StellarSdkStrKey.encodePreAuthTx>) =>
+    StellarSdkStrKey.encodePreAuthTx(...args) as PreAuthTx),
   decodePreAuthTx: StellarSdkStrKey.decodePreAuthTx,
-  encodeSha256Hash: StellarSdkStrKey.encodeSha256Hash,
+  encodeSha256Hash: ((...args: Parameters<typeof StellarSdkStrKey.encodeSha256Hash>) =>
+    StellarSdkStrKey.encodeSha256Hash(...args) as Sha256Hash),
   decodeSha256Hash: StellarSdkStrKey.decodeSha256Hash,
-  encodeSignedPayload: StellarSdkStrKey.encodeSignedPayload,
+  encodeSignedPayload: ((...args: Parameters<typeof StellarSdkStrKey.encodeSignedPayload>) =>
+    StellarSdkStrKey.encodeSignedPayload(...args) as SignedPayload),
   decodeSignedPayload: StellarSdkStrKey.decodeSignedPayload,
-  encodeLiquidityPool: StellarSdkStrKey.encodeLiquidityPool,
+  encodeLiquidityPool: ((...args: Parameters<typeof StellarSdkStrKey.encodeLiquidityPool>) =>
+    StellarSdkStrKey.encodeLiquidityPool(...args) as LiquidityPoolId),
   decodeLiquidityPool: StellarSdkStrKey.decodeLiquidityPool,
-  encodeClaimableBalance: StellarSdkStrKey.encodeClaimableBalance,
+  encodeClaimableBalance: ((...args: Parameters<typeof StellarSdkStrKey.encodeClaimableBalance>) =>
+    StellarSdkStrKey.encodeClaimableBalance(...args) as ClaimableBalanceId),
   decodeClaimableBalance: StellarSdkStrKey.decodeClaimableBalance,
-  encodeEd25519PublicKey: StellarSdkStrKey.encodeEd25519PublicKey,
+  encodeEd25519PublicKey: ((
+    ...args: Parameters<typeof StellarSdkStrKey.encodeEd25519PublicKey>
+  ) => StellarSdkStrKey.encodeEd25519PublicKey(...args) as Ed25519PublicKey),
   decodeEd25519PublicKey: StellarSdkStrKey.decodeEd25519PublicKey,
-  encodeEd25519SecretSeed: StellarSdkStrKey.encodeEd25519SecretSeed,
+  encodeEd25519SecretSeed: ((
+    ...args: Parameters<typeof StellarSdkStrKey.encodeEd25519SecretSeed>
+  ) => StellarSdkStrKey.encodeEd25519SecretSeed(...args) as Ed25519SecretKey),
   decodeEd25519SecretSeed: StellarSdkStrKey.decodeEd25519SecretSeed,
-  encodeMed25519PublicKey: StellarSdkStrKey.encodeMed25519PublicKey,
+  encodeMed25519PublicKey: ((
+    ...args: Parameters<typeof StellarSdkStrKey.encodeMed25519PublicKey>
+  ) => StellarSdkStrKey.encodeMed25519PublicKey(...args) as MuxedAddress),
   decodeMed25519PublicKey: StellarSdkStrKey.decodeMed25519PublicKey,
 };
 

--- a/core/strkeys/index.unit.test.ts
+++ b/core/strkeys/index.unit.test.ts
@@ -1,46 +1,48 @@
 import { assertEquals } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
+import { Buffer } from "buffer";
+import { Keypair, xdr } from "stellar-sdk";
 import { StrKey } from "@/strkeys/index.ts";
-import { StrkeyPrefix, StrkeyName } from "@/strkeys/types.ts";
+import { StrkeyName, StrkeyPrefix } from "@/strkeys/types.ts";
 
 describe("StrKey", () => {
   describe("getStrkeyTypeName", () => {
     it("returns correct type name for each prefix", () => {
       assertEquals(
         StrKey.getStrkeyTypeName(StrkeyPrefix.Ed25519PublicKey),
-        "ed25519PublicKey"
+        "ed25519PublicKey",
       );
       assertEquals(
         StrKey.getStrkeyTypeName(StrkeyPrefix.Ed25519SecretKey),
-        "ed25519SecretKey"
+        "ed25519SecretKey",
       );
       assertEquals(
         StrKey.getStrkeyTypeName(StrkeyPrefix.Med25519PublicKey),
-        "med25519PublicKey"
+        "med25519PublicKey",
       );
       assertEquals(
         StrKey.getStrkeyTypeName(StrkeyPrefix.PreAuthTx),
-        "preAuthTx"
+        "preAuthTx",
       );
       assertEquals(
         StrKey.getStrkeyTypeName(StrkeyPrefix.Sha256Hash),
-        "sha256Hash"
+        "sha256Hash",
       );
       assertEquals(
         StrKey.getStrkeyTypeName(StrkeyPrefix.SignedPayload),
-        "signedPayload"
+        "signedPayload",
       );
       assertEquals(
         StrKey.getStrkeyTypeName(StrkeyPrefix.ContractId),
-        "contract"
+        "contract",
       );
       assertEquals(
         StrKey.getStrkeyTypeName(StrkeyPrefix.LiquidityPoolId),
-        "liquidityPool"
+        "liquidityPool",
       );
       assertEquals(
         StrKey.getStrkeyTypeName(StrkeyPrefix.ClaimableBalanceId),
-        "claimableBalance"
+        "claimableBalance",
       );
     });
   });
@@ -49,81 +51,81 @@ describe("StrKey", () => {
     it("detects G prefix (Ed25519 public key)", () => {
       assertEquals(
         StrKey.detectStrkeyType(
-          "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
+          "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
         ),
-        StrkeyName.G
+        StrkeyName.G,
       );
     });
 
     it("detects S prefix (Ed25519 secret key)", () => {
       assertEquals(
         StrKey.detectStrkeyType(
-          "SBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWHOKR"
+          "SBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWHOKR",
         ),
-        StrkeyName.S
+        StrkeyName.S,
       );
     });
 
     it("detects M prefix (Muxed address)", () => {
       assertEquals(
         StrKey.detectStrkeyType(
-          "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ"
+          "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ",
         ),
-        StrkeyName.M
+        StrkeyName.M,
       );
     });
 
     it("detects T prefix (PreAuthTx)", () => {
       assertEquals(
         StrKey.detectStrkeyType(
-          "TBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWHXL7"
+          "TBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWHXL7",
         ),
-        StrkeyName.T
+        StrkeyName.T,
       );
     });
 
     it("detects X prefix (HashX)", () => {
       assertEquals(
         StrKey.detectStrkeyType(
-          "XBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWGTOG"
+          "XBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWGTOG",
         ),
-        StrkeyName.X
+        StrkeyName.X,
       );
     });
 
     it("detects P prefix (Signed payload)", () => {
       assertEquals(
         StrKey.detectStrkeyType(
-          "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAQACAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUPB6IBZGM"
+          "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAQACAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUPB6IBZGM",
         ),
-        StrkeyName.P
+        StrkeyName.P,
       );
     });
 
     it("detects C prefix (Contract)", () => {
       assertEquals(
         StrKey.detectStrkeyType(
-          "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA"
+          "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA",
         ),
-        StrkeyName.C
+        StrkeyName.C,
       );
     });
 
     it("detects L prefix (Liquidity pool)", () => {
       assertEquals(
         StrKey.detectStrkeyType(
-          "LA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUPJN"
+          "LA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUPJN",
         ),
-        StrkeyName.L
+        StrkeyName.L,
       );
     });
 
     it("detects B prefix (Claimable balance)", () => {
       assertEquals(
         StrKey.detectStrkeyType(
-          "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU"
+          "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU",
         ),
-        StrkeyName.B
+        StrkeyName.B,
       );
     });
 
@@ -140,24 +142,24 @@ describe("StrKey", () => {
       it("accepts valid G addresses", () => {
         assertEquals(
           StrKey.isEd25519PublicKey(
-            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
+            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
           ),
-          true
+          true,
         );
         assertEquals(
           StrKey.isEd25519PublicKey(
-            "GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB"
+            "GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB",
           ),
-          true
+          true,
         );
       });
 
       it("rejects wrong prefix", () => {
         assertEquals(
           StrKey.isEd25519PublicKey(
-            "SA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
+            "SA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
           ),
-          false
+          false,
         );
       });
 
@@ -165,18 +167,18 @@ describe("StrKey", () => {
         assertEquals(StrKey.isEd25519PublicKey("GAAAAAAAACGC6"), false);
         assertEquals(
           StrKey.isEd25519PublicKey(
-            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZA"
+            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZA",
           ),
-          false
+          false,
         );
       });
 
       it("rejects invalid base32 characters", () => {
         assertEquals(
           StrKey.isEd25519PublicKey(
-            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJV1G8"
+            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJV1G8",
           ),
-          false
+          false,
         );
       });
     });
@@ -185,24 +187,24 @@ describe("StrKey", () => {
       it("accepts valid S addresses", () => {
         assertEquals(
           StrKey.isEd25519SecretKey(
-            "SBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWHOKR"
+            "SBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWHOKR",
           ),
-          true
+          true,
         );
         assertEquals(
           StrKey.isEd25519SecretKey(
-            "SAB5556L5AN5KSR5WF7UOEFDCIODEWEO7H2UR4S5R62DFTQOGLKOVZDY"
+            "SAB5556L5AN5KSR5WF7UOEFDCIODEWEO7H2UR4S5R62DFTQOGLKOVZDY",
           ),
-          true
+          true,
         );
       });
 
       it("rejects wrong prefix", () => {
         assertEquals(
           StrKey.isEd25519SecretKey(
-            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
+            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
           ),
-          false
+          false,
         );
       });
 
@@ -210,9 +212,9 @@ describe("StrKey", () => {
         assertEquals(StrKey.isEd25519SecretKey("SABC234567890"), false);
         assertEquals(
           StrKey.isEd25519SecretKey(
-            "SAFGAMN5Z6IHVI3IVEPIILS7ITZDYSCEPLN4FN5Z3IY63DRH4CIYEV"
+            "SAFGAMN5Z6IHVI3IVEPIILS7ITZDYSCEPLN4FN5Z3IY63DRH4CIYEV",
           ),
-          false
+          false,
         );
       });
     });
@@ -221,24 +223,24 @@ describe("StrKey", () => {
       it("accepts valid M addresses", () => {
         assertEquals(
           StrKey.isMuxedAddress(
-            "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ"
+            "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ",
           ),
-          true
+          true,
         );
         assertEquals(
           StrKey.isMuxedAddress(
-            "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK"
+            "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK",
           ),
-          true
+          true,
         );
       });
 
       it("rejects wrong prefix", () => {
         assertEquals(
           StrKey.isMuxedAddress(
-            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
+            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
           ),
-          false
+          false,
         );
       });
     });
@@ -247,18 +249,18 @@ describe("StrKey", () => {
       it("accepts valid P addresses", () => {
         assertEquals(
           StrKey.isSignedPayload(
-            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAQACAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUPB6IBZGM"
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAQACAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUPB6IBZGM",
           ),
-          true
+          true,
         );
       });
 
       it("rejects wrong prefix", () => {
         assertEquals(
           StrKey.isSignedPayload(
-            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
+            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
           ),
-          false
+          false,
         );
       });
     });
@@ -267,18 +269,18 @@ describe("StrKey", () => {
       it("accepts valid C addresses", () => {
         assertEquals(
           StrKey.isContractId(
-            "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE"
+            "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE",
           ),
-          true
+          true,
         );
       });
 
       it("rejects wrong prefix", () => {
         assertEquals(
           StrKey.isContractId(
-            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
+            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
           ),
-          false
+          false,
         );
       });
     });
@@ -287,18 +289,18 @@ describe("StrKey", () => {
       it("accepts valid T addresses", () => {
         assertEquals(
           StrKey.isPreAuthTx(
-            "TBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWHXL7"
+            "TBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWHXL7",
           ),
-          true
+          true,
         );
       });
 
       it("rejects wrong prefix", () => {
         assertEquals(
           StrKey.isPreAuthTx(
-            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
+            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
           ),
-          false
+          false,
         );
       });
     });
@@ -307,18 +309,18 @@ describe("StrKey", () => {
       it("accepts valid X addresses", () => {
         assertEquals(
           StrKey.isSha256Hash(
-            "XBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWGTOG"
+            "XBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWGTOG",
           ),
-          true
+          true,
         );
       });
 
       it("rejects wrong prefix", () => {
         assertEquals(
           StrKey.isSha256Hash(
-            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
+            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
           ),
-          false
+          false,
         );
       });
     });
@@ -327,9 +329,9 @@ describe("StrKey", () => {
       it("accepts valid L addresses", () => {
         assertEquals(
           StrKey.isLiquidityPoolId(
-            "LA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUPJN"
+            "LA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUPJN",
           ),
-          true
+          true,
         );
       });
     });
@@ -338,9 +340,9 @@ describe("StrKey", () => {
       it("accepts valid B addresses", () => {
         assertEquals(
           StrKey.isClaimableBalanceId(
-            "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU"
+            "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU",
           ),
-          true
+          true,
         );
       });
     });
@@ -351,42 +353,42 @@ describe("StrKey", () => {
       it("validates valid Ed25519 public keys", () => {
         assertEquals(
           StrKey.isValidEd25519PublicKey(
-            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
+            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
           ),
-          true
+          true,
         );
         assertEquals(
           StrKey.isValidEd25519PublicKey(
-            "GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB"
+            "GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB",
           ),
-          true
+          true,
         );
       });
 
       it("rejects invalid length (congruent to 1 mod 8)", () => {
         assertEquals(
           StrKey.isValidEd25519PublicKey(
-            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZA"
+            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZA",
           ),
-          false
+          false,
         );
       });
 
       it("rejects invalid algorithm (low 3 bits are 7)", () => {
         assertEquals(
           StrKey.isValidEd25519PublicKey(
-            "G47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVP2I"
+            "G47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVP2I",
           ),
-          false
+          false,
         );
       });
 
       it("rejects invalid checksum", () => {
         assertEquals(
           StrKey.isValidEd25519PublicKey(
-            "GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVT"
+            "GBPXXOA5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVT",
           ),
-          false
+          false,
         );
       });
 
@@ -397,28 +399,28 @@ describe("StrKey", () => {
       it("rejects base-32 yielding wrong byte count (36 not 35)", () => {
         assertEquals(
           StrKey.isValidEd25519PublicKey(
-            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUACUSI"
+            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUACUSI",
           ),
-          false
+          false,
         );
       });
 
       it("rejects when decoded data encodes to different string", () => {
         assertEquals(
           StrKey.isValidEd25519PublicKey(
-            "GBPXX0A5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL"
+            "GBPXX0A5N4JYPESHAADMQKBPWZWQDQ64ZV6ZL2S3LAGW4SY7NTCMWIVL",
             //    ^ note the '0' (zero) instead of 'O' (letter O)
             // This might decode, but re-encoding produces a different string
           ),
-          false
+          false,
         );
         assertEquals(
           StrKey.isValidEd25519PublicKey(
-            "GCFZB6L25D26RQFDWSSBDEYQ32JHLRMTT44ZYE3DZQUTYOL7WY43PLBG++"
+            "GCFZB6L25D26RQFDWSSBDEYQ32JHLRMTT44ZYE3DZQUTYOL7WY43PLBG++",
             //                                                              ^^ invalid chars
             // The ++ is clearly not valid base32
           ),
-          false
+          false,
         );
       });
     });
@@ -427,24 +429,24 @@ describe("StrKey", () => {
       it("validates valid Ed25519 secret keys", () => {
         assertEquals(
           StrKey.isValidEd25519SecretSeed(
-            "SBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWHOKR"
+            "SBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWHOKR",
           ),
-          true
+          true,
         );
         assertEquals(
           StrKey.isValidEd25519SecretSeed(
-            "SAB5556L5AN5KSR5WF7UOEFDCIODEWEO7H2UR4S5R62DFTQOGLKOVZDY"
+            "SAB5556L5AN5KSR5WF7UOEFDCIODEWEO7H2UR4S5R62DFTQOGLKOVZDY",
           ),
-          true
+          true,
         );
       });
 
       it("rejects when format check fails (wrong prefix)", () => {
         assertEquals(
           StrKey.isValidEd25519SecretSeed(
-            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
+            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
           ),
-          false
+          false,
         );
       });
     });
@@ -453,60 +455,60 @@ describe("StrKey", () => {
       it("validates valid muxed addresses", () => {
         assertEquals(
           StrKey.isValidMuxedAddress(
-            "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ"
+            "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ",
           ),
-          true
+          true,
         );
         assertEquals(
           StrKey.isValidMuxedAddress(
-            "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK"
+            "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK",
           ),
-          true
+          true,
         );
       });
 
       it("rejects unused trailing bit not zero", () => {
         assertEquals(
           StrKey.isValidMuxedAddress(
-            "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUR"
+            "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUR",
           ),
-          false
+          false,
         );
       });
 
       it("rejects invalid algorithm (low 3 bits are 7)", () => {
         assertEquals(
           StrKey.isValidMuxedAddress(
-            "M47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ"
+            "M47QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ",
           ),
-          false
+          false,
         );
       });
 
       it("rejects padding bytes", () => {
         assertEquals(
           StrKey.isValidMuxedAddress(
-            "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUK==="
+            "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUK===",
           ),
-          false
+          false,
         );
       });
 
       it("rejects invalid checksum", () => {
         assertEquals(
           StrKey.isValidMuxedAddress(
-            "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUO"
+            "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUO",
           ),
-          false
+          false,
         );
       });
 
       it("rejects muxed with wrong decoded byte count (44 not 43)", () => {
         assertEquals(
           StrKey.isValidMuxedAddress(
-            "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAAV75I"
+            "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAAV75I",
           ),
-          false
+          false,
         );
       });
     });
@@ -515,24 +517,24 @@ describe("StrKey", () => {
       it("validates valid signed payloads", () => {
         assertEquals(
           StrKey.isValidSignedPayload(
-            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAQACAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUPB6IBZGM"
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAQACAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUPB6IBZGM",
           ),
-          true
+          true,
         );
         assertEquals(
           StrKey.isValidSignedPayload(
-            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUAAAAFGBU"
+            "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUAAAAFGBU",
           ),
-          true
+          true,
         );
       });
 
       it("rejects when format check fails (wrong prefix)", () => {
         assertEquals(
           StrKey.isValidSignedPayload(
-            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
+            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
           ),
-          false
+          false,
         );
       });
     });
@@ -541,18 +543,18 @@ describe("StrKey", () => {
       it("validates valid contracts", () => {
         assertEquals(
           StrKey.isValidContractId(
-            "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE"
+            "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE",
           ),
-          true
+          true,
         );
       });
 
       it("rejects when format check fails (wrong prefix)", () => {
         assertEquals(
           StrKey.isValidContractId(
-            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
+            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
           ),
-          false
+          false,
         );
       });
     });
@@ -561,18 +563,18 @@ describe("StrKey", () => {
       it("validates valid liquidity pools", () => {
         assertEquals(
           StrKey.isValidLiquidityPoolId(
-            "LA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUPJN"
+            "LA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUPJN",
           ),
-          true
+          true,
         );
       });
 
       it("rejects when format check fails (wrong prefix)", () => {
         assertEquals(
           StrKey.isValidLiquidityPoolId(
-            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
+            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
           ),
-          false
+          false,
         );
       });
     });
@@ -581,27 +583,27 @@ describe("StrKey", () => {
       it("validates valid claimable balances", () => {
         assertEquals(
           StrKey.isValidClaimableBalanceId(
-            "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU"
+            "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU",
           ),
-          true
+          true,
         );
       });
 
       it("rejects trailing bits not zero", () => {
         assertEquals(
           StrKey.isValidClaimableBalanceId(
-            "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TV"
+            "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TV",
           ),
-          false
+          false,
         );
       });
 
       it("rejects when format check fails (wrong prefix)", () => {
         assertEquals(
           StrKey.isValidClaimableBalanceId(
-            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
+            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
           ),
-          false
+          false,
         );
       });
     });
@@ -618,9 +620,9 @@ describe("StrKey", () => {
       // Expected: false (length prefix declares fewer bytes than actual payload)
       assertEquals(
         StrKey.isValidSignedPayload(
-          "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAQACAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUPB6IAAAAAAAAPM"
+          "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAQACAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUPB6IAAAAAAAAPM",
         ),
-        true // <- KNOWN-ISSUE
+        true, // <- KNOWN-ISSUE
       );
     });
 
@@ -628,9 +630,9 @@ describe("StrKey", () => {
       // Expected: false (length prefix declares more bytes than actual payload)
       assertEquals(
         StrKey.isValidSignedPayload(
-          "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4Z2PQ"
+          "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4Z2PQ",
         ),
-        true // <- KNOWN-ISSUE
+        true, // <- KNOWN-ISSUE
       );
     });
 
@@ -638,9 +640,9 @@ describe("StrKey", () => {
       // Expected: false (payloads < 64 bytes must be zero-padded to 64 bytes)
       assertEquals(
         StrKey.isValidSignedPayload(
-          "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DXFH6"
+          "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DXFH6",
         ),
-        true // <- KNOWN-ISSUE
+        true, // <- KNOWN-ISSUE
       );
     });
 
@@ -648,10 +650,34 @@ describe("StrKey", () => {
       // Expected: false (first byte should be 0x00 for CLAIMABLE_BALANCE_ID_TYPE_V0)
       assertEquals(
         StrKey.isValidClaimableBalanceId(
-          "BAAT6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGXACA"
+          "BAAT6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGXACA",
         ),
-        true // <- KNOWN-ISSUE
+        true, // <- KNOWN-ISSUE
       );
+    });
+  });
+
+  describe("encode helpers", () => {
+    it("encodes pre-authorized transaction hashes", () => {
+      const encoded = StrKey.encodePreAuthTx(Buffer.alloc(32, 7));
+      assertEquals(StrKey.isPreAuthTx(encoded), true);
+    });
+
+    it("encodes signed payloads", () => {
+      const signerPayload = new xdr.SignerKeyEd25519SignedPayload({
+        ed25519: Keypair.random().rawPublicKey(),
+        payload: Buffer.from([1, 2, 3]),
+      });
+
+      const encoded = StrKey.encodeSignedPayload(signerPayload.toXDR());
+      assertEquals(StrKey.isSignedPayload(encoded), true);
+    });
+
+    it("encodes ed25519 secret seeds", () => {
+      const secret = StrKey.encodeEd25519SecretSeed(
+        Keypair.random().rawSecretKey(),
+      );
+      assertEquals(StrKey.isEd25519SecretKey(secret), true);
     });
   });
 });

--- a/core/strkeys/index.unit.test.ts
+++ b/core/strkeys/index.unit.test.ts
@@ -670,14 +670,14 @@ describe("StrKey", () => {
       });
 
       const encoded = StrKey.encodeSignedPayload(signerPayload.toXDR());
-      assertEquals(StrKey.isSignedPayload(encoded), true);
+      assertEquals(StrKey.isValidSignedPayload(encoded), true);
     });
 
     it("encodes ed25519 secret seeds", () => {
       const secret = StrKey.encodeEd25519SecretSeed(
         Keypair.random().rawSecretKey(),
       );
-      assertEquals(StrKey.isEd25519SecretKey(secret), true);
+      assertEquals(StrKey.isValidEd25519SecretSeed(secret), true);
     });
   });
 });

--- a/core/tools/friendbot/error.ts
+++ b/core/tools/friendbot/error.ts
@@ -3,10 +3,14 @@ import { ToolsError } from "@/tools/error.ts";
 export enum Code {
   UNEXPECTED = "TOOL_FRDBOT_000",
   INVALID_ADDRESS = "TOOL_FRDBOT_001",
+  RPC_PROPAGATION_TIMEOUT = "TOOL_FRDBOT_002",
 }
 
 export type MetaData = {
   friendbotUrl: string;
+  publicKey?: string;
+  rpcUrl?: string;
+  timeoutInMs?: number;
 };
 
 export abstract class FriendbotError extends ToolsError<Code, MetaData> {
@@ -49,7 +53,37 @@ export class INVALID_ADDRESS extends FriendbotError {
   }
 }
 
+export class RPC_PROPAGATION_TIMEOUT extends FriendbotError {
+  constructor(
+    friendbotUrl: string,
+    publicKey: string,
+    rpcUrl: string,
+    timeoutInMs: number,
+  ) {
+    super({
+      code: Code.RPC_PROPAGATION_TIMEOUT,
+      message:
+        `Account ${publicKey} was funded but did not become visible on RPC within ${timeoutInMs}ms.`,
+      data: {
+        friendbotUrl,
+        publicKey,
+        rpcUrl,
+        timeoutInMs,
+      },
+      details:
+        "Friendbot funding succeeded, but the account never became readable from the configured RPC endpoint within the allotted timeout.",
+      diagnostic: {
+        rootCause:
+          "RPC propagation lagged behind the Friendbot funding response or the configured RPC endpoint was unhealthy.",
+        suggestion:
+          "Verify the RPC URL, increase the propagation timeout, or retry once the network catches up.",
+      },
+    });
+  }
+}
+
 export const ERROR_TOOL_FRDBOT = {
   [Code.UNEXPECTED]: UNEXPECTED,
   [Code.INVALID_ADDRESS]: INVALID_ADDRESS,
+  [Code.RPC_PROPAGATION_TIMEOUT]: RPC_PROPAGATION_TIMEOUT,
 };

--- a/core/tools/friendbot/index.unit.test.ts
+++ b/core/tools/friendbot/index.unit.test.ts
@@ -125,7 +125,7 @@ describe("initializeWithFriendbot", () => {
     }
   });
 
-  it("throws UNEXPECTED when RPC propagation times out", async () => {
+  it("throws RPC_PROPAGATION_TIMEOUT when RPC propagation times out", async () => {
     const fetchStub = stub(globalThis, "fetch", () =>
       Promise.resolve(new Response("OK", { status: 200 }))
     );
@@ -145,11 +145,11 @@ describe("initializeWithFriendbot", () => {
             timeoutInMs: 1,
             pollIntervalInMs: 0,
           }),
-        E.UNEXPECTED,
+        E.RPC_PROPAGATION_TIMEOUT,
       );
 
       assertEquals(
-        error.meta.cause?.message,
+        error.message,
         `Account ${TEST_PUBLIC} was funded but did not become visible on RPC within 1ms.`,
       );
     } finally {

--- a/core/tools/friendbot/initialize-with-friendbot.ts
+++ b/core/tools/friendbot/initialize-with-friendbot.ts
@@ -15,6 +15,7 @@ export type InitializeWithFriendbotOptions = {
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const waitForRpcPropagation = async (
+  friendbotUrl: string,
   publicKey: Ed25519PublicKey,
   options?: InitializeWithFriendbotOptions,
 ) => {
@@ -36,8 +37,11 @@ const waitForRpcPropagation = async (
     }
   }
 
-  throw new Error(
-    `Account ${publicKey} was funded but did not become visible on RPC within ${timeoutInMs}ms.`,
+  throw new E.RPC_PROPAGATION_TIMEOUT(
+    friendbotUrl,
+    publicKey,
+    options.rpcUrl,
+    timeoutInMs,
   );
 };
 
@@ -70,10 +74,13 @@ export const initializeWithFriendbot = async (
       );
     }
 
-    await waitForRpcPropagation(publicKey, options);
+    await waitForRpcPropagation(friendbotUrl, publicKey, options);
 
     return;
   } catch (e) {
+    if (e instanceof E.FriendbotError) {
+      throw e;
+    }
     throw new E.UNEXPECTED(friendbotUrl, e as Error);
   }
 };

--- a/deno.json
+++ b/deno.json
@@ -12,7 +12,7 @@
     "jsr:@colibri/test-tooling": "./test-tooling",
     "colibri-internal/": "./_internal/",
     "colibri-tools/": "./_tools/",
-    "stellar-sdk": "npm:@stellar/stellar-sdk@^14.6.1",
+    "stellar-sdk": "npm:@stellar/stellar-sdk@^15.0.1",
     "buffer": "npm:buffer@^6.0.3",
     "crypto": "node:crypto",
     "convee": "jsr:@fifo/convee@1.0.0",

--- a/test-tooling/quickstart/error.ts
+++ b/test-tooling/quickstart/error.ts
@@ -107,7 +107,7 @@ export abstract class QuickstartError<
       data: args.data,
     };
 
-    super(args.message);
+    super(args.message, meta.cause ? { cause: meta.cause } : undefined);
     this.name = `QuickstartError ${args.code}`;
     this.code = args.code;
     this.details = args.details;

--- a/test-tooling/quickstart/error.unit.test.ts
+++ b/test-tooling/quickstart/error.unit.test.ts
@@ -30,6 +30,7 @@ describe("Quickstart errors", () => {
     assertStrictEquals(error.domain, "tools");
     assertStrictEquals(error.source, "@colibri/test-tooling/quickstart");
     assertStrictEquals(error.code, Code.INVALID_CONFIGURATION);
+    assertStrictEquals(error.cause, undefined);
     assertEquals(error.meta, {
       cause: null,
       data: {
@@ -108,6 +109,8 @@ describe("Quickstart errors", () => {
       cause: new Error("boom"),
     });
     assertStrictEquals(dockerError.meta.cause?.message, "boom");
+    assertInstanceOf(dockerError.cause, Error);
+    assertStrictEquals(dockerError.cause.message, "boom");
     assertEquals(dockerError.meta.data, {});
 
     const containerError = new CONTAINER_ERROR({
@@ -117,6 +120,8 @@ describe("Quickstart errors", () => {
       data: { containerId: "abc" },
     });
     assertStrictEquals(containerError.meta.cause?.message, "broken");
+    assertInstanceOf(containerError.cause, Error);
+    assertStrictEquals(containerError.cause.message, "broken");
     assertEquals(containerError.meta.data, { containerId: "abc" });
 
     const imageError = new IMAGE_ERROR({
@@ -125,6 +130,8 @@ describe("Quickstart errors", () => {
       cause: { status: "bad" },
     });
     assertStrictEquals(imageError.meta.cause?.message, '{"status":"bad"}');
+    assertInstanceOf(imageError.cause, Error);
+    assertStrictEquals(imageError.cause.message, '{"status":"bad"}');
     assertEquals(imageError.meta.data, {});
 
     const circularCause: { label: string; self?: unknown; toString(): string } =
@@ -145,6 +152,8 @@ describe("Quickstart errors", () => {
       fallbackCauseError.meta.cause?.message,
       "circular-cause",
     );
+    assertInstanceOf(fallbackCauseError.cause, Error);
+    assertStrictEquals(fallbackCauseError.cause.message, "circular-cause");
     assertEquals(fallbackCauseError.meta.data, {});
   });
 

--- a/test-tooling/quickstart/index.integration.test.ts
+++ b/test-tooling/quickstart/index.integration.test.ts
@@ -27,7 +27,7 @@ describe("StellarTestLedger", () => {
   const stellarTestLedger = new StellarTestLedger({
     logLevel,
     containerName: "colibri-stellar-test-ledger-stable",
-    containerImageVersion: "v425-latest",
+    containerImageVersion: "latest",
   });
 
   afterAll(async () => {

--- a/test-tooling/quickstart/runtime.ts
+++ b/test-tooling/quickstart/runtime.ts
@@ -117,6 +117,14 @@ const formatError = (error: unknown): string => {
 };
 
 /**
+ * Appends the formatted underlying error message when one is available.
+ */
+const withUnderlyingError = (message: string, error: unknown): string => {
+  const formatted = formatError(error).trim();
+  return formatted ? `${message} Cause: ${formatted}` : message;
+};
+
+/**
  * Wraps unknown failures in a quickstart error when needed.
  */
 const ensureQuickstartError = <T extends QuickstartError>(
@@ -362,7 +370,10 @@ export const findContainerByName = async (
     throw ensureQuickstartError(
       error,
       new CONTAINER_ERROR({
-        message: "Failed to list Docker containers.",
+        message: withUnderlyingError(
+          "Failed to list Docker containers.",
+          error,
+        ),
         details:
           "Quickstart could not inspect the local Docker daemon while looking up a named container.",
         data: { containerName: name },

--- a/test-tooling/quickstart/runtime.ts
+++ b/test-tooling/quickstart/runtime.ts
@@ -153,9 +153,16 @@ const waitForFriendbotReady = async (
     return;
   }
 
-  throw new Error(
-    `Friendbot is not ready yet (status: ${response.status}, body: ${body}).`,
-  );
+  throw new READINESS_ERROR({
+    message: "Friendbot is not ready yet.",
+    details:
+      `Friendbot is not ready yet (status: ${response.status}, body: ${body}).`,
+    data: {
+      friendbotUrl: probe.friendbotUrl,
+      status: response.status,
+      body,
+    },
+  });
 };
 
 const isTerminalReadinessError = (error: unknown): boolean => {

--- a/test-tooling/quickstart/runtime.ts
+++ b/test-tooling/quickstart/runtime.ts
@@ -117,14 +117,6 @@ const formatError = (error: unknown): string => {
 };
 
 /**
- * Appends the formatted underlying error message when one is available.
- */
-const withUnderlyingError = (message: string, error: unknown): string => {
-  const formatted = formatError(error).trim();
-  return formatted ? `${message} Cause: ${formatted}` : message;
-};
-
-/**
  * Wraps unknown failures in a quickstart error when needed.
  */
 const ensureQuickstartError = <T extends QuickstartError>(
@@ -370,10 +362,7 @@ export const findContainerByName = async (
     throw ensureQuickstartError(
       error,
       new CONTAINER_ERROR({
-        message: withUnderlyingError(
-          "Failed to list Docker containers.",
-          error,
-        ),
+        message: "Failed to list Docker containers.",
         details:
           "Quickstart could not inspect the local Docker daemon while looking up a named container.",
         data: { containerName: name },

--- a/test-tooling/quickstart/runtime.unit.test.ts
+++ b/test-tooling/quickstart/runtime.unit.test.ts
@@ -180,7 +180,7 @@ describe("Quickstart runtime helpers", () => {
           } as unknown as DockerClientLike,
         }),
       CONTAINER_ERROR,
-      "Failed to list Docker containers. Cause: daemon unavailable",
+      "Failed to list Docker containers.",
     );
     assertStrictEquals(causeWrappedError.code, Code.CONTAINER_ERROR);
     assertStrictEquals(causeWrappedError.meta.cause, dockerFailure);

--- a/test-tooling/quickstart/runtime.unit.test.ts
+++ b/test-tooling/quickstart/runtime.unit.test.ts
@@ -170,6 +170,21 @@ describe("Quickstart runtime helpers", () => {
       "already wrapped",
     );
     assertStrictEquals(wrappedError.code, Code.CONTAINER_ERROR);
+
+    const dockerFailure = new Error("daemon unavailable");
+    const causeWrappedError = await assertRejects(
+      () =>
+        findContainerByName("broken", {
+          dockerClient: {
+            listContainers: () => Promise.reject(dockerFailure),
+          } as unknown as DockerClientLike,
+        }),
+      CONTAINER_ERROR,
+      "Failed to list Docker containers. Cause: daemon unavailable",
+    );
+    assertStrictEquals(causeWrappedError.code, Code.CONTAINER_ERROR);
+    assertStrictEquals(causeWrappedError.meta.cause, dockerFailure);
+    assertStrictEquals(causeWrappedError.cause, dockerFailure);
   });
 
   it("runtime helpers can create a real Docker client when none is injected", async () => {


### PR DESCRIPTION
## Summary

Adds a new `LedgerEntries` feature to `@colibri/core` for reading Stellar ledger entries through RPC with typed convenience methods, generic access helpers, and exported key builders.

## What Changed

- added the new `core/ledger-entries` module with:
  - typed convenience methods for well-known ledger entry kinds
  - generic `get` and `getMany` helpers
  - branded ledger-key builders for typed inference without changing runtime shape
  - decoding helpers and typed error handling
- exposed the new surface from `@colibri/core`
- updated native account helpers to share the branded key builders
- added trustline-asset parsing helpers needed by the new decoders
- documented the new feature in the core README
- added unit and integration coverage for the new module and restored full coverage to 100%

## Why

Reading ledger entries directly from Stellar RPC currently requires callers to manually assemble ledger-key XDR and manually decode the returned entry XDR. This change provides a higher-level SDK surface for common entry types while still exposing the underlying XDR for advanced usage.

## Impact

Developers can now read common ledger entries through a simpler typed API while still retaining access to the original XDR payloads. Advanced users can also build and reuse branded keys directly for generic reads and typed batch access.

## Validation

- `deno test core/ledger-entries/index.unit.test.ts core/ledger-entries/keys.unit.test.ts core/ledger-entries/decode.unit.test.ts core/ledger-entries/error.unit.test.ts core/common/helpers/xdr/parse-trustline-asset.unit.test.ts core/strkeys/index.unit.test.ts`
- `deno task test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `LedgerEntries` API for typed Stellar RPC reads of common ledger entry types (account, trustline, offer, data, claimable balance, liquidity pool, contract data/instance/code, config settings, and TTL), eliminating manual ledger key construction and XDR parsing for standard workflows.
  * Added lower-level branded ledger-key builders for advanced use cases requiring direct `getMany` access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->