### PR TITLE
Document LedgerEntries in GitBook docs

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -16,6 +16,7 @@
     - [SEP-11](core/asset/sep-11.md)
     - [Stellar Asset Contract](core/asset/stellar-asset-contract.md)
   - [Contract](core/contract.md)
+  - [Ledger Entries](core/ledger-entries.md)
   - [Network](core/network.md)
   - [SEP-1](core/sep1.md)
   - [Signer](core/signer/README.md)

--- a/docs/core/ledger-entries.md
+++ b/docs/core/ledger-entries.md
@@ -1,0 +1,244 @@
+# Ledger Entries
+
+`LedgerEntries` is Colibri's high-level RPC helper for reading live Stellar
+ledger state without manually assembling `LedgerKey` XDR or walking raw entry
+XDR responses yourself.
+
+It is designed for two kinds of usage:
+
+- **simple typed reads** for well-known entry kinds such as accounts,
+  trustlines, offers, and contract entries
+- **lower-level key-based reads** when you want to build ledger keys yourself
+  and still get typed decoding
+
+## Creating A Reader
+
+You can bind `LedgerEntries` to either a `NetworkConfig` or an existing RPC
+instance:
+
+```ts
+import { LedgerEntries, NetworkConfig } from "@colibri/core";
+
+const networkConfig = NetworkConfig.TestNet();
+
+const ledger = new LedgerEntries({ networkConfig });
+```
+
+```ts
+import { LedgerEntries, NetworkConfig } from "@colibri/core";
+import { Server } from "stellar-sdk/rpc";
+
+const networkConfig = NetworkConfig.TestNet();
+const rpc = new Server(networkConfig.rpcUrl!, {
+  allowHttp: networkConfig.allowHttp ?? false,
+});
+
+const ledger = new LedgerEntries({ rpc });
+```
+
+## Convenience Reads
+
+`LedgerEntries` exposes direct helpers for the common well-known entry types:
+
+- `account(...)`
+- `trustline(...)`
+- `offer(...)`
+- `data(...)`
+- `claimableBalance(...)`
+- `liquidityPool(...)`
+- `contractData(...)`
+- `contractInstance(...)`
+- `contractCode(...)`
+- `configSetting(...)`
+
+Example:
+
+```ts
+import { LedgerEntries, NetworkConfig } from "@colibri/core";
+import { Asset } from "stellar-sdk";
+
+const networkConfig = NetworkConfig.TestNet();
+const ledger = new LedgerEntries({ networkConfig });
+
+const account = await ledger.account({
+  accountId: "GA...",
+});
+
+const trustline = await ledger.trustline({
+  accountId: "GA...",
+  asset: new Asset("USDC", "GB..."),
+});
+
+console.log(account.balance);
+console.log(trustline.limit);
+console.log(trustline.flags.authorized);
+```
+
+These convenience methods are the right choice when you know the entry kind in
+advance and want a typed result immediately.
+
+If the requested entry does not exist, these convenience methods raise typed
+ledger-entry errors instead of returning `null`.
+
+## The Returned Shape
+
+Each decoded result includes friendly fields for the entry type plus an `xdr`
+property for advanced inspection.
+
+```ts
+const instance = await ledger.contractInstance({
+  contractId: "CA...",
+});
+
+console.log(instance.type); // "contractInstance"
+console.log(instance.executable);
+console.log(instance.xdr); // parsed RPC entry payload
+```
+
+This keeps the simple path ergonomic without hiding the original parsed RPC
+entry from advanced callers.
+
+## Generic Reads
+
+Use `get(...)` when you already have a ledger key and want a nullable typed
+lookup:
+
+```ts
+import {
+  LedgerEntries,
+  NetworkConfig,
+  buildAccountLedgerKey,
+} from "@colibri/core";
+
+const ledger = new LedgerEntries({
+  networkConfig: NetworkConfig.TestNet(),
+});
+
+const entry = await ledger.get(
+  buildAccountLedgerKey({ accountId: "GA..." }),
+);
+
+if (entry) {
+  console.log(entry.balance);
+}
+```
+
+Use `getMany(...)` when you want to fetch multiple entries in one RPC call
+while preserving input order:
+
+```ts
+import {
+  LedgerEntries,
+  NetworkConfig,
+  buildAccountLedgerKey,
+  buildConfigSettingLedgerKey,
+} from "@colibri/core";
+
+const ledger = new LedgerEntries({
+  networkConfig: NetworkConfig.TestNet(),
+});
+
+const [account, configSetting] = await ledger.getMany([
+  buildAccountLedgerKey({ accountId: "GA..." }),
+  buildConfigSettingLedgerKey({
+    configSettingId: "configSettingContractMaxSizeBytes",
+  }),
+] as const);
+```
+
+Unlike the convenience methods, `get(...)` and `getMany(...)` return `null`
+when an entry is missing instead of raising a not-found error.
+
+## Ledger Key Builders
+
+The ledger-entry module also exports granular key builders so advanced callers
+can work directly with `xdr.LedgerKey` values:
+
+- `buildAccountLedgerKey(...)`
+- `buildTrustlineLedgerKey(...)`
+- `buildOfferLedgerKey(...)`
+- `buildDataLedgerKey(...)`
+- `buildClaimableBalanceLedgerKey(...)`
+- `buildLiquidityPoolLedgerKey(...)`
+- `buildContractDataLedgerKey(...)`
+- `buildContractInstanceLedgerKey(...)`
+- `buildContractCodeLedgerKey(...)`
+- `buildConfigSettingLedgerKey(...)`
+- `buildTtlLedgerKey(...)`
+- `hashLedgerKey(...)`
+
+These builders return plain `xdr.LedgerKey` objects at runtime, but Colibri
+brands them at the type level so `get(...)` and `getMany(...)` can preserve the
+expected entry type when you use the exported builders.
+
+## Contract Data Notes
+
+Classic Stellar entry kinds have well-defined decoded shapes. Contract storage
+does not.
+
+That means `contractData(...)` gives you a friendly wrapper around the entry,
+but it does **not** try to infer a contract-specific application schema.
+Instead, it gives you access to the parsed key/value forms so you can decode
+them according to your own contract conventions.
+
+```ts
+import { LedgerEntries, NetworkConfig } from "@colibri/core";
+import { xdr } from "stellar-sdk";
+
+const ledger = new LedgerEntries({
+  networkConfig: NetworkConfig.TestNet(),
+});
+
+const data = await ledger.contractData({
+  contractId: "CA...",
+  key: xdr.ScVal.scvSymbol("counter"),
+});
+
+console.log(data.key);
+console.log(data.value);
+```
+
+## Contract Code Lookup
+
+`contractCode(...)` supports two lookup styles:
+
+- by explicit wasm hash
+- by `contractId`, resolving the contract instance first
+
+```ts
+const code = await ledger.contractCode({
+  contractId: "CA...",
+});
+
+console.log(code.hash);
+console.log(code.code.length);
+```
+
+## TTL Keys
+
+The module can build TTL keys and TTL key hashes:
+
+```ts
+import {
+  buildContractInstanceLedgerKey,
+  buildTtlLedgerKey,
+  hashLedgerKey,
+} from "@colibri/core";
+
+const contractKey = buildContractInstanceLedgerKey({
+  contractId: "CA...",
+});
+
+const ttlKey = buildTtlLedgerKey({ key: contractKey });
+const keyHash = hashLedgerKey(contractKey);
+```
+
+However, direct TTL reads are not exposed through `LedgerEntries` because the
+shared RPC ledger-entry read path does not support them cleanly today.
+
+## Next Steps
+
+- [Contract](contract.md) — High-level Soroban client
+- [Network](network.md) — Network configuration
+- [Stellar Asset Contract](asset/stellar-asset-contract.md) — SAC-specific
+  client

--- a/docs/core/overview.md
+++ b/docs/core/overview.md
@@ -2,7 +2,8 @@
 
 `@colibri/core` is the foundation package for the Colibri toolkit. It exposes
 the main clients, transaction configuration types, low-level process
-functions, step factories, built-in pipelines, event helpers, and tooling.
+functions, step factories, built-in pipelines, event helpers, ledger-state
+accessors, and tooling.
 
 ## Installation
 
@@ -75,7 +76,12 @@ const result = await pipeline.run({
 ### High-Level Clients
 
 ```ts
-import { Contract, NetworkConfig, StellarAssetContract } from "@colibri/core";
+import {
+  Contract,
+  LedgerEntries,
+  NetworkConfig,
+  StellarAssetContract,
+} from "@colibri/core";
 
 const network = NetworkConfig.TestNet();
 
@@ -88,6 +94,32 @@ const sac = StellarAssetContract.fromContractId({
   networkConfig: network,
   contractId: "CBI...",
 });
+
+const ledger = new LedgerEntries({
+  networkConfig: network,
+});
+```
+
+### Ledger State Access
+
+```ts
+import {
+  LedgerEntries,
+  NetworkConfig,
+  buildAccountLedgerKey,
+} from "@colibri/core";
+
+const ledger = new LedgerEntries({
+  networkConfig: NetworkConfig.TestNet(),
+});
+
+const account = await ledger.account({
+  accountId: "GA...",
+});
+
+const generic = await ledger.get(
+  buildAccountLedgerKey({ accountId: "GA..." }),
+);
 ```
 
 ### Event Parsing
@@ -149,6 +181,7 @@ try {
 
 - use high-level clients when you want ergonomics and a stable object-oriented
   interface
+- use `LedgerEntries` when you want typed RPC access to live ledger state
 - use `create*Pipeline(...)` when you want to attach plugins or own the flow
 - use `steps` when you need stable orchestration ids
 - use raw processes when you want isolated single-purpose behavior
@@ -156,6 +189,7 @@ try {
 ## Next Steps
 
 - [Contract](contract.md) — High-level Soroban client
+- [Ledger Entries](ledger-entries.md) — Typed RPC access to live ledger state
 - [Stellar Asset Contract](asset/stellar-asset-contract.md) — SAC-specific
   client
 - [Pipelines](pipelines/README.md) — Built-in write and read flows


### PR DESCRIPTION
## Summary
Adds GitBook documentation for the new `LedgerEntries` API in `@colibri/core`.

## Changes
- adds a dedicated `docs/core/ledger-entries.md` page
- links the page from `docs/SUMMARY.md`
- updates `docs/core/overview.md` so ledger-state access is visible from the core landing page

## Notes
This is a docs-only PR. No runtime code changes are included.