### PR TITLE
Update GitBook documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A TypeScript-first toolkit for building robust Stellar and Soroban applications 
 </p>
 
 <p align="center">
-  <a href="https://colibri-docs.gitbook.io/">📚 Documentation</a> | <a href="https://github.com/fazzatti/colibri-examples">💡 Examples</a>
+  <a href="https://fifo-docs.gitbook.io/colibri">📚 Documentation</a> | <a href="https://github.com/fazzatti/colibri-examples">💡 Examples</a>
 </p>
 
 <div align="center">

--- a/core/README.md
+++ b/core/README.md
@@ -5,7 +5,7 @@ Soroban workflows. Currently in beta release with hardened error handling,
 transaction orchestration, account primitives, and typed helpers ready for
 integrated pipelines.
 
-[📚 Documentation](https://colibri-docs.gitbook.io/) |
+[📚 Documentation](https://fifo-docs.gitbook.io/colibri) |
 [💡 Examples](https://github.com/fazzatti/colibri-examples)
 
 ## Installation

--- a/plugins/channel-accounts/README.md
+++ b/plugins/channel-accounts/README.md
@@ -3,7 +3,7 @@
 Utilities for managing sponsored Stellar channel accounts and reusing them in
 Colibri classic and Soroban transaction pipelines.
 
-[📚 Documentation](https://colibri-docs.gitbook.io/) |
+[📚 Documentation](https://fifo-docs.gitbook.io/colibri) |
 [💡 Examples](https://github.com/fazzatti/colibri-examples)
 
 ## Exports

--- a/plugins/fee-bump/README.md
+++ b/plugins/fee-bump/README.md
@@ -7,7 +7,7 @@ It targets the `SendTransaction` step from `@colibri/core`. You can attach it to
 any `convee` pipe that includes `steps.SEND_TRANSACTION_STEP_ID` (for example,
 one created by `createInvokeContractPipeline`).
 
-[📚 Documentation](https://colibri-docs.gitbook.io/) |
+[📚 Documentation](https://fifo-docs.gitbook.io/colibri) |
 [💡 Examples](https://github.com/fazzatti/colibri-examples)
 
 ## Quick start

--- a/sep10/README.md
+++ b/sep10/README.md
@@ -2,7 +2,7 @@
 
 SEP-10 Web Authentication client for Stellar. Part of the [Colibri](https://github.com/fazzatti/colibri) ecosystem.
 
-[📚 Documentation](https://colibri-docs.gitbook.io/) | [💡 Examples](https://github.com/fazzatti/colibri-examples)
+[📚 Documentation](https://fifo-docs.gitbook.io/colibri) | [💡 Examples](https://github.com/fazzatti/colibri-examples)
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- update README documentation links to the new GitBook URL
- point package-level docs links at `https://fifo-docs.gitbook.io/colibri`

## Validation
- `git diff --check`

Docs-only change.