### PR TITLE
Add ledger and createdAt to send transaction output

### DIFF
--- a/core/pipelines/classic-transaction/index.unit.test.ts
+++ b/core/pipelines/classic-transaction/index.unit.test.ts
@@ -159,6 +159,8 @@ describe("createClassicTransactionPipeline", () => {
       it("transforms SendTransactionOutput to ClassicTransactionOutput", async () => {
         const mockSendOutput: SendTransactionOutput = {
           hash: "mock-hash-123",
+          ledger: 12345,
+          createdAt: Date.now(),
           returnValue: xdr.ScVal.scvVoid(),
           response: {} as unknown as Api.GetSuccessfulTransactionResponse,
         };

--- a/core/processes/send-transaction/index.ts
+++ b/core/processes/send-transaction/index.ts
@@ -13,7 +13,7 @@ import { ResultOrError } from "@/common/deferred/result-or-error.ts";
 
 /** Submits a signed transaction to Stellar RPC and waits for a terminal result. */
 export const sendTransaction = async (
-  input: SendTransactionInput
+  input: SendTransactionInput,
 ): Promise<SendTransactionOutput> => {
   try {
     const { transaction, rpc, options } = input;
@@ -25,17 +25,17 @@ export const sendTransaction = async (
 
     assertRequiredArgs(
       { transaction, rpc },
-      (argName: string) => new E.MISSING_ARG(input, argName)
+      (argName: string) => new E.MISSING_ARG(input, argName),
     );
 
     assert(
       timeoutInSeconds >= 1,
-      new E.TIMEOUT_TOO_LOW(input, timeoutInSeconds)
+      new E.TIMEOUT_TOO_LOW(input, timeoutInSeconds),
     );
 
     assert(
       waitIntervalInMs >= 100,
-      new E.WAIT_INTERVAL_TOO_LOW(input, waitIntervalInMs)
+      new E.WAIT_INTERVAL_TOO_LOW(input, waitIntervalInMs),
     );
 
     let sendResponse: Api.SendTransactionResponse;
@@ -60,7 +60,7 @@ export const sendTransaction = async (
           input,
           txHash,
           sendResponse.errorResult,
-          sendResponse.diagnosticEvents
+          sendResponse.diagnosticEvents,
         );
 
       throw new E.UNEXPECTED_STATUS(input, txHash, sendResponse.status);
@@ -80,6 +80,8 @@ export const sendTransaction = async (
       return {
         hash: txHash,
         returnValue: getTxResponse.returnValue,
+        ledger: getTxResponse.ledger,
+        createdAt: getTxResponse.createdAt,
         response: getTxResponse,
       };
 
@@ -93,7 +95,7 @@ export const sendTransaction = async (
     throw new E.UNEXPECTED_STATUS(
       input,
       txHash,
-      (getTxResponse as Api.GetTransactionResponse).status
+      (getTxResponse as Api.GetTransactionResponse).status,
     );
   } catch (e) {
     if (e instanceof E.SendTransactionError) {
@@ -107,7 +109,7 @@ const getTransactionRecursively = async (
   rpc: Server,
   hash: string,
   waitUntil: number,
-  waitIntervalInMs: number
+  waitIntervalInMs: number,
 ): Promise<
   ResultOrError<
     Api.GetTransactionResponse,

--- a/core/processes/send-transaction/types.ts
+++ b/core/processes/send-transaction/types.ts
@@ -58,6 +58,10 @@ export type SendTransactionOutput = {
   hash: string;
   /** Soroban return value, when the submitted transaction produced one. */
   returnValue: XdrScVal | undefined;
+  /** Ledger sequence in which the transaction was included. */
+  ledger: number;
+  /** Timestamp (in ms since epoch) when the transaction was included in the ledger. */
+  createdAt: number;
   /** Full successful response returned by Stellar RPC. */
   response: RpcSuccessfulTransactionResponse;
 };

--- a/plugins/channel-accounts/src/plugin/index.unit.test.ts
+++ b/plugins/channel-accounts/src/plugin/index.unit.test.ts
@@ -54,6 +54,8 @@ describe("ChannelAccounts", () => {
 
   const createInvokePipelineOutput = (): InvokeContractOutput => ({
     hash: "invoke-hash",
+    ledger: 12345,
+    createdAt: Date.now(),
     response: {} as InvokeContractOutput["response"],
     returnValue: undefined,
   });
@@ -93,9 +95,10 @@ describe("ChannelAccounts", () => {
         CLASSIC_TRANSACTION_PIPELINE_ID,
         INVOKE_CONTRACT_PIPELINE_ID,
       ]);
-      assertEquals(plugin.getChannels().map((item) => item.address()), [
-        channel.address(),
-      ]);
+      assertEquals(
+        plugin.getChannels().map((item) => item.address()),
+        [channel.address()],
+      );
     });
 
     it("registers channels after construction and exposes proxy members", () => {
@@ -110,7 +113,10 @@ describe("ChannelAccounts", () => {
       assertEquals("getChannels" in plugin, true);
       assertEquals("id" in plugin, true);
       assertEquals(
-        plugin.getChannels().map((item) => item.address()).sort(),
+        plugin
+          .getChannels()
+          .map((item) => item.address())
+          .sort(),
         [channel.address(), extraChannel.address()].sort(),
       );
     });
@@ -147,9 +153,10 @@ describe("ChannelAccounts", () => {
       );
 
       assertEquals(result.hash, "classic-hash");
-      assertEquals(plugin.getChannels().map((item) => item.address()), [
-        channel.address(),
-      ]);
+      assertEquals(
+        plugin.getChannels().map((item) => item.address()),
+        [channel.address()],
+      );
     });
 
     it("ignores output release when no channel is allocated", () => {
@@ -157,12 +164,14 @@ describe("ChannelAccounts", () => {
         channels: [channel],
       });
       const output = createClassicPipelineOutput();
-      const outputHook = (plugin as {
-        output(
-          this: unknown,
-          output: ClassicTransactionOutput,
-        ): ClassicTransactionOutput;
-      }).output;
+      const outputHook = (
+        plugin as {
+          output(
+            this: unknown,
+            output: ClassicTransactionOutput,
+          ): ClassicTransactionOutput;
+        }
+      ).output;
 
       const result = outputHook.call(
         {
@@ -208,9 +217,10 @@ describe("ChannelAccounts", () => {
         "boom",
       );
 
-      assertEquals(plugin.getChannels().map((item) => item.address()), [
-        channel.address(),
-      ]);
+      assertEquals(
+        plugin.getChannels().map((item) => item.address()),
+        [channel.address()],
+      );
 
       const recoveryPipeline = pipe(
         [
@@ -239,9 +249,10 @@ describe("ChannelAccounts", () => {
       );
 
       assertEquals(result.hash, "invoke-hash");
-      assertEquals(plugin.getChannels().map((item) => item.address()), [
-        channel.address(),
-      ]);
+      assertEquals(
+        plugin.getChannels().map((item) => item.address()),
+        [channel.address()],
+      );
     });
 
     it("accepts an explicit pipeline target", () => {

--- a/plugins/fee-bump/src/index.unit.test.ts
+++ b/plugins/fee-bump/src/index.unit.test.ts
@@ -66,9 +66,7 @@ describe("FeeBump Plugin", () => {
       },
     });
 
-  const createPluginTestPipe = (
-    onInput?: (input: PluginInput) => void,
-  ) =>
+  const createPluginTestPipe = (onInput?: (input: PluginInput) => void) =>
     pipe(
       [
         step(
@@ -76,6 +74,8 @@ describe("FeeBump Plugin", () => {
             onInput?.(input);
             return {
               hash: "mock-hash",
+              ledger: 12345,
+              createdAt: Date.now(),
               returnValue: undefined,
               response: {} as Api.GetSuccessfulTransactionResponse,
             };
@@ -107,7 +107,7 @@ describe("FeeBump Plugin", () => {
       assertEquals(invokePipe.id, INVOKE_CONTRACT_PIPELINE_ID);
       assertEquals(invokePipe.plugins.length, 1);
       const [attachedPlugin] = Array.from(
-        invokePipe.plugins as unknown as readonly typeof plugin[],
+        invokePipe.plugins as unknown as readonly (typeof plugin)[],
       );
       assertExists(attachedPlugin);
       assertEquals(attachedPlugin.id, FEE_BUMP_PLUGIN_ID);
@@ -142,8 +142,9 @@ describe("FeeBump Plugin", () => {
       );
       assertEquals(interceptedInput.transaction.fee, "20000000");
       assertEquals(
-        (interceptedInput.transaction as FeeBumpTransaction).innerTransaction
-          .toXDR(),
+        (
+          interceptedInput.transaction as FeeBumpTransaction
+        ).innerTransaction.toXDR(),
         mockTransaction.toXDR(),
       );
     });


### PR DESCRIPTION
## Summary
- add `ledger` and `createdAt` to `SendTransactionOutput`
- propagate the new fields through the send-transaction process output
- update the related unit tests in core and plugins

## Validation
- tests and checks already passed locally