### PR TITLE
Add JSR badges to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,45 @@ A TypeScript-first toolkit for building robust Stellar and Soroban applications 
   <a href="https://fifo-docs.gitbook.io/colibri">📚 Documentation</a> | <a href="https://github.com/fazzatti/colibri-examples">💡 Examples</a>
 </p>
 
+<p align="center">
+  <a href="https://jsr.io/@colibri/core">
+    <img src="https://jsr.io/badges/@colibri/core" alt="JSR @colibri/core" />
+  </a>
+  <a href="https://jsr.io/@colibri/core">
+    <img src="https://jsr.io/badges/@colibri/core/total-downloads" alt="JSR total downloads for @colibri/core" />
+  </a>
+  <a href="https://jsr.io/@colibri/sep10">
+    <img src="https://jsr.io/badges/@colibri/sep10" alt="JSR @colibri/sep10" />
+  </a>
+  <a href="https://jsr.io/@colibri/sep10">
+    <img src="https://jsr.io/badges/@colibri/sep10/total-downloads" alt="JSR total downloads for @colibri/sep10" />
+  </a>
+  <a href="https://jsr.io/@colibri/plugin-fee-bump">
+    <img src="https://jsr.io/badges/@colibri/plugin-fee-bump" alt="JSR @colibri/plugin-fee-bump" />
+  </a>
+  <a href="https://jsr.io/@colibri/plugin-fee-bump">
+    <img src="https://jsr.io/badges/@colibri/plugin-fee-bump/total-downloads" alt="JSR total downloads for @colibri/plugin-fee-bump" />
+  </a>
+  <a href="https://jsr.io/@colibri/plugin-channel-accounts">
+    <img src="https://jsr.io/badges/@colibri/plugin-channel-accounts" alt="JSR @colibri/plugin-channel-accounts" />
+  </a>
+  <a href="https://jsr.io/@colibri/plugin-channel-accounts">
+    <img src="https://jsr.io/badges/@colibri/plugin-channel-accounts/total-downloads" alt="JSR total downloads for @colibri/plugin-channel-accounts" />
+  </a>
+  <a href="https://jsr.io/@colibri/rpc-streamer">
+    <img src="https://jsr.io/badges/@colibri/rpc-streamer" alt="JSR @colibri/rpc-streamer" />
+  </a>
+  <a href="https://jsr.io/@colibri/rpc-streamer">
+    <img src="https://jsr.io/badges/@colibri/rpc-streamer/total-downloads" alt="JSR total downloads for @colibri/rpc-streamer" />
+  </a>
+  <a href="https://jsr.io/@colibri/test-tooling">
+    <img src="https://jsr.io/badges/@colibri/test-tooling" alt="JSR @colibri/test-tooling" />
+  </a>
+  <a href="https://jsr.io/@colibri/test-tooling">
+    <img src="https://jsr.io/badges/@colibri/test-tooling/total-downloads" alt="JSR total downloads for @colibri/test-tooling" />
+  </a>
+</p>
+
 <div align="center">
 
 <a href="https://github.com/fazzatti/colibri/actions/workflows/deno.yml">

--- a/core/README.md
+++ b/core/README.md
@@ -5,6 +5,13 @@ Soroban workflows. Currently in beta release with hardened error handling,
 transaction orchestration, account primitives, and typed helpers ready for
 integrated pipelines.
 
+<a href="https://jsr.io/@colibri/core">
+  <img src="https://jsr.io/badges/@colibri/core" alt="JSR @colibri/core" />
+</a>
+<a href="https://jsr.io/@colibri/core">
+  <img src="https://jsr.io/badges/@colibri/core/total-downloads" alt="JSR total downloads for @colibri/core" />
+</a>
+
 [📚 Documentation](https://fifo-docs.gitbook.io/colibri) |
 [💡 Examples](https://github.com/fazzatti/colibri-examples)
 

--- a/plugins/channel-accounts/README.md
+++ b/plugins/channel-accounts/README.md
@@ -3,6 +3,13 @@
 Utilities for managing sponsored Stellar channel accounts and reusing them in
 Colibri classic and Soroban transaction pipelines.
 
+<a href="https://jsr.io/@colibri/plugin-channel-accounts">
+  <img src="https://jsr.io/badges/@colibri/plugin-channel-accounts" alt="JSR @colibri/plugin-channel-accounts" />
+</a>
+<a href="https://jsr.io/@colibri/plugin-channel-accounts">
+  <img src="https://jsr.io/badges/@colibri/plugin-channel-accounts/total-downloads" alt="JSR total downloads for @colibri/plugin-channel-accounts" />
+</a>
+
 [📚 Documentation](https://fifo-docs.gitbook.io/colibri) |
 [💡 Examples](https://github.com/fazzatti/colibri-examples)
 

--- a/plugins/fee-bump/README.md
+++ b/plugins/fee-bump/README.md
@@ -3,6 +3,13 @@
 A Colibri plugin that wraps a Stellar Transaction in a Fee Bump Transaction so a
 designated account pays the fees.
 
+<a href="https://jsr.io/@colibri/plugin-fee-bump">
+  <img src="https://jsr.io/badges/@colibri/plugin-fee-bump" alt="JSR @colibri/plugin-fee-bump" />
+</a>
+<a href="https://jsr.io/@colibri/plugin-fee-bump">
+  <img src="https://jsr.io/badges/@colibri/plugin-fee-bump/total-downloads" alt="JSR total downloads for @colibri/plugin-fee-bump" />
+</a>
+
 It targets the `SendTransaction` step from `@colibri/core`. You can attach it to
 any `convee` pipe that includes `steps.SEND_TRANSACTION_STEP_ID` (for example,
 one created by `createInvokeContractPipeline`).

--- a/rpc-streamer/README.md
+++ b/rpc-streamer/README.md
@@ -2,6 +2,13 @@
 
 A generic RPC streaming framework for building custom Stellar data streamers. The `RPCStreamer<T>` class handles all the complex streaming logic—archive-to-live transitions, checkpoints, error handling, pagination—so you can focus on defining what data to extract.
 
+<a href="https://jsr.io/@colibri/rpc-streamer">
+  <img src="https://jsr.io/badges/@colibri/rpc-streamer" alt="JSR @colibri/rpc-streamer" />
+</a>
+<a href="https://jsr.io/@colibri/rpc-streamer">
+  <img src="https://jsr.io/badges/@colibri/rpc-streamer/total-downloads" alt="JSR total downloads for @colibri/rpc-streamer" />
+</a>
+
 ## Overview
 
 This package provides two ways to stream Stellar blockchain data:

--- a/sep10/README.md
+++ b/sep10/README.md
@@ -2,6 +2,13 @@
 
 SEP-10 Web Authentication client for Stellar. Part of the [Colibri](https://github.com/fazzatti/colibri) ecosystem.
 
+<a href="https://jsr.io/@colibri/sep10">
+  <img src="https://jsr.io/badges/@colibri/sep10" alt="JSR @colibri/sep10" />
+</a>
+<a href="https://jsr.io/@colibri/sep10">
+  <img src="https://jsr.io/badges/@colibri/sep10/total-downloads" alt="JSR total downloads for @colibri/sep10" />
+</a>
+
 [📚 Documentation](https://fifo-docs.gitbook.io/colibri) | [💡 Examples](https://github.com/fazzatti/colibri-examples)
 
 ## Installation

--- a/test-tooling/README.md
+++ b/test-tooling/README.md
@@ -6,6 +6,13 @@ The main public API is `StellarTestLedger`, a Docker-backed harness that starts,
 reuses, inspects, stops, and destroys a Stellar Quickstart instance for
 integration tests.
 
+<a href="https://jsr.io/@colibri/test-tooling">
+  <img src="https://jsr.io/badges/@colibri/test-tooling" alt="JSR @colibri/test-tooling" />
+</a>
+<a href="https://jsr.io/@colibri/test-tooling">
+  <img src="https://jsr.io/badges/@colibri/test-tooling/total-downloads" alt="JSR total downloads for @colibri/test-tooling" />
+</a>
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Summary
- add JSR version badges to the root README package index
- add JSR version and total-downloads badges to each published package README
- keep the change scoped to documentation only

## Why
This makes the package docs point directly at the JSR package pages and surfaces package adoption at both the package and workspace entrypoints.

## Validation
- no automated checks run; README-only change