### PR TITLE
fix(assemble-transaction): use BigInt for sequence math

### DIFF
--- a/core/processes/assemble-transaction/index.ts
+++ b/core/processes/assemble-transaction/index.ts
@@ -43,9 +43,13 @@ export const assembleTransaction = async (
       auth: authEntries,
     });
 
+    // Use BigInt math: Soroban sequence numbers are `ledger << 32 | n`, which
+    // exceeds Number.MAX_SAFE_INTEGER (2^53 - 1) once the ledger passes ~2.1M.
+    // `Number(seq) - 1` silently rounds to the nearest representable double,
+    // producing the wrong source seq and causing `txBadSeq` on submission.
     const sourceAccount = new Account(
       transaction.source,
-      (Number(transaction.sequence) - 1).toString()
+      (BigInt(transaction.sequence) - 1n).toString()
     );
 
     let builtSorobanData: xdr.SorobanTransactionData | undefined;

--- a/core/processes/assemble-transaction/index.unit.test.ts
+++ b/core/processes/assemble-transaction/index.unit.test.ts
@@ -75,6 +75,44 @@ describe("AssembleTransaction", () => {
       assertEquals(result.fee, "18"); // 10 inclusion fee + 3 resource fee from soroban data + 5 resource fee from input
     });
 
+    it("preserves source sequence above Number.MAX_SAFE_INTEGER (2^53)", async () => {
+      // Soroban sequence numbers are `ledger << 32 | n`. Once the ledger
+      // passes ~2.1M, sequences exceed 2^53 and Number() loses precision.
+      // Regression test: a build-output sequence of 9_771_475_800_162_306
+      // must round-trip through assemble unchanged.
+      const builtSeq = "9771475800162306";
+      const account = new Account(
+        "GB3MXH633VRECLZRUAR3QCLQJDMXNYNHKZCO6FJEWXVWSUEIS7NU376P",
+        // TransactionBuilder.build adds 1, so seed with builtSeq - 1
+        (BigInt(builtSeq) - 1n).toString(),
+      );
+      const transaction = new TransactionBuilder(account, {
+        fee: "100",
+        networkPassphrase: NetworkConfig.TestNet().networkPassphrase,
+      })
+        .addOperation(
+          Operation.invokeContractFunction({
+            contract:
+              "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+            function: "transfer",
+            args: [],
+          }),
+        )
+        .setTimeout(0)
+        .build();
+
+      assertEquals(transaction.sequence, builtSeq);
+
+      const result = await assembleTransaction({
+        transaction,
+        sorobanData: new SorobanDataBuilder(),
+        authEntries: [],
+        resourceFee: 0,
+      });
+
+      assertEquals(result.sequence, builtSeq);
+    });
+
     it("executes with soroban data and auth entries", async () => {
       const transaction = createTestTransaction();
       const sorobanData = new SorobanDataBuilder();


### PR DESCRIPTION
## Summary

`AssembleTransaction` re-derives the source `Account` from the input transaction's sequence so that `TransactionBuilder.build()` reproduces the same final sequence. The current implementation uses `Number(transaction.sequence) - 1`, which silently loses precision once the sequence exceeds `Number.MAX_SAFE_INTEGER` (`2^53 - 1`).

For Soroban, sequence numbers are `ledger << 32 | n`. On testnet (and on mainnet today) the ledger is well past `~2.1M`, so every sequence is already past `2^53`. Within `[2^53, 2^54)` only even integers are exactly representable, so `Number("9771475800162306") - 1` returns `9771475800162304` (rounded down by 2), and `build()`'s subsequent `+1` produces `9771475800162305` — the already-consumed seq from the previous transaction.

The submission is then rejected by Soroban RPC with `txBadSeq`. The failure is intermittent in practice because some sequence values round-trip stably and some don't:

| built seq         | `(Number - 1).toString()` | final after `+1` | result |
|-------------------|---------------------------|------------------|--------|
| `9771475800162305` | `9771475800162304`        | `9771475800162305` | OK (stable by luck) |
| `9771475800162306` | `9771475800162304`        | `9771475800162305` | **txBadSeq** |
| `9771475800162307` | `9771475800162308`        | `9771475800162309` | wrong |

## Fix

Switch to `BigInt` arithmetic — the same string-in, string-out shape the rest of the SDK uses for sequence numbers.

```ts
// before
const sourceAccount = new Account(
  transaction.source,
  (Number(transaction.sequence) - 1).toString()
);

// after
const sourceAccount = new Account(
  transaction.source,
  (BigInt(transaction.sequence) - 1n).toString()
);
```

## How this was found

Diagnostic tracing on a real testnet replay surfaced:

- `tx.pre_build_account_seq` = `9771475800162305` (RPC last-consumed)
- `tx.attempted_seq` (after assemble, on submit) = `9771475800162305`
- Soroban returned `txBadSeq`

Build had correctly produced `...306`; assemble's Number coercion collapsed it back to `...305`.

## Test plan

- [x] Added regression test in `core/processes/assemble-transaction/index.unit.test.ts` that asserts a built sequence above `2^53` round-trips through assemble unchanged
- [x] `deno lint` clean
- [x] `deno task check` clean
- [x] `deno task test:unit` — 142 passed (2169 steps), 0 failed

## Notes

- There's a similar pattern in `sep10/src/utils/utils.unit.test.ts:73` but it's only in a test helper, so it's lower priority. Happy to fix in a follow-up if you'd like.
- Targeting `dev` per the repo's promote-to-main workflow.