### PR TITLE
Accept structural binary data inputs

### DIFF
--- a/core/common/helpers/binary.ts
+++ b/core/common/helpers/binary.ts
@@ -1,0 +1,13 @@
+import type { BinaryData } from "@/common/types/index.ts";
+import { toBuffer } from "@/common/helpers/internal-buffer.ts";
+
+/**
+ * Converts any Colibri-supported binary input into a stable Uint8Array shape.
+ *
+ * This is the public binary normalization helper. Internal Stellar SDK
+ * boundaries may still convert the result to Buffer without exposing that
+ * package-specific type to Colibri consumers.
+ */
+export function normalizeBinaryData(value: BinaryData): Uint8Array {
+  return toBuffer(value);
+}

--- a/core/common/helpers/binary.unit.test.ts
+++ b/core/common/helpers/binary.unit.test.ts
@@ -1,0 +1,35 @@
+import { assertEquals } from "@std/assert";
+import { normalizeBinaryData } from "@/common/helpers/binary.ts";
+
+Deno.test("normalizeBinaryData preserves Uint8Array bytes", () => {
+  const bytes = new Uint8Array([1, 2, 3]);
+
+  const normalized = normalizeBinaryData(bytes);
+
+  assertEquals([...normalized], [1, 2, 3]);
+});
+
+Deno.test("normalizeBinaryData preserves ArrayBuffer bytes", () => {
+  const bytes = new Uint8Array([4, 5, 6]);
+
+  const normalized = normalizeBinaryData(bytes.buffer);
+
+  assertEquals([...normalized], [4, 5, 6]);
+});
+
+Deno.test("normalizeBinaryData respects typed array byte offsets", () => {
+  const bytes = new Uint8Array([0, 7, 8, 9, 0]).subarray(1, 4);
+
+  const normalized = normalizeBinaryData(bytes);
+
+  assertEquals([...normalized], [7, 8, 9]);
+});
+
+Deno.test("normalizeBinaryData accepts DataView inputs", () => {
+  const bytes = new Uint8Array([0, 10, 11, 12, 0]);
+  const view = new DataView(bytes.buffer, 1, 3);
+
+  const normalized = normalizeBinaryData(view);
+
+  assertEquals([...normalized], [10, 11, 12]);
+});

--- a/core/common/helpers/calculate-contract-id.ts
+++ b/core/common/helpers/calculate-contract-id.ts
@@ -1,6 +1,8 @@
-import { hash, Address, xdr } from "stellar-sdk";
+import { Address, hash, xdr } from "stellar-sdk";
 import { Buffer } from "buffer";
 import { StrKey } from "@/strkeys/index.ts";
+import type { BinaryData } from "@/common/types/index.ts";
+import { toBuffer } from "@/common/helpers/internal-buffer.ts";
 
 /**
  * Calculates the expected contract ID from an address and salt.
@@ -11,7 +13,7 @@ import { StrKey } from "@/strkeys/index.ts";
 export function calculateContractId(
   networkPassphrase: string,
   sourceAddress: string,
-  salt: Uint8Array
+  salt: BinaryData,
 ): string {
   const networkId = hash(Buffer.from(networkPassphrase));
 
@@ -21,10 +23,10 @@ export function calculateContractId(
       contractIdPreimage: xdr.ContractIdPreimage.contractIdPreimageFromAddress(
         new xdr.ContractIdPreimageFromAddress({
           address: new Address(sourceAddress).toScAddress(),
-          salt: Buffer.from(salt),
-        })
+          salt: toBuffer(salt),
+        }),
       ),
-    })
+    }),
   );
 
   return StrKey.encodeContract(hash(preimage.toXDR()));

--- a/core/common/helpers/index.ts
+++ b/core/common/helpers/index.ts
@@ -1,5 +1,6 @@
 export * from "@/common/helpers/boolean.ts";
 export * from "@/common/helpers/bounded-array.ts";
+export * from "@/common/helpers/binary.ts";
 export * from "@/common/helpers/string.ts";
 export * from "@/common/helpers/xdr/index.ts";
 export * from "@/common/helpers/transaction.ts";

--- a/core/common/helpers/internal-buffer.ts
+++ b/core/common/helpers/internal-buffer.ts
@@ -1,0 +1,15 @@
+import { Buffer } from "buffer";
+import type { BinaryData } from "@/common/types/index.ts";
+
+/**
+ * Converts Colibri-supported binary input into the Buffer shape expected by
+ * Stellar SDK helpers. Keep this helper internal so the public API stays
+ * decoupled from a specific `buffer` package version.
+ */
+export function toBuffer(value: BinaryData): Buffer {
+  if (value instanceof ArrayBuffer) {
+    return Buffer.from(value);
+  }
+
+  return Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+}

--- a/core/common/helpers/wasm.ts
+++ b/core/common/helpers/wasm.ts
@@ -1,10 +1,11 @@
 import { cereal, xdr } from "stellar-sdk";
-import type { Buffer } from "buffer";
+import type { BinaryData } from "@/common/types/index.ts";
+import { toBuffer } from "@/common/helpers/internal-buffer.ts";
 
 // extracted from stellar-sdk
 // https://github.com/stellar/js-stellar-sdk/blob/master/src/contract/utils.ts
-export function processSpecEntryStream(buffer: Buffer) {
-  const reader = new cereal.XdrReader(buffer);
+export function processSpecEntryStream(buffer: BinaryData) {
+  const reader = new cereal.XdrReader(toBuffer(buffer));
   const res: xdr.ScSpecEntry[] = [];
   while (!reader.eof) {
     // deno-lint-ignore no-explicit-any

--- a/core/common/types/external.ts
+++ b/core/common/types/external.ts
@@ -1,9 +1,10 @@
 /**
- * Minimal binary payload used by Colibri's public cryptographic helpers.
+ * Minimal binary payload used by Colibri's public byte-oriented APIs.
  *
- * `Buffer` values remain assignable because they extend `Uint8Array`.
+ * This intentionally accepts structural JavaScript byte containers instead of
+ * exposing a specific `buffer` package version as part of Colibri's public API.
  */
-export type BinaryData = Uint8Array;
+export type BinaryData = ArrayBuffer | ArrayBufferView;
 
 /**
  * Minimal XDR-serializable surface exposed by low-level Colibri APIs.

--- a/core/contract/index.ts
+++ b/core/contract/index.ts
@@ -23,6 +23,7 @@ import {
 } from "@/common/helpers/get-transaction-response.ts";
 import { processSpecEntryStream } from "@/common/helpers/wasm.ts";
 import { generateRandomSalt } from "@/common/helpers/generate-random-salt.ts";
+import { toBuffer } from "@/common/helpers/internal-buffer.ts";
 import * as E from "@/contract/error.ts";
 import type { ContractConstructorArgs } from "@/contract/types.ts";
 import type { Api } from "stellar-sdk/rpc";
@@ -108,7 +109,7 @@ export class Contract {
       this.contractId = contractId;
     }
     if (wasm) {
-      this.wasm = wasm;
+      this.wasm = toBuffer(wasm);
     }
     if (wasmHash) {
       this.wasmHash = wasmHash;
@@ -250,7 +251,7 @@ export class Contract {
 
     try {
       const uploadOperation = Operation.uploadContractWasm({
-        wasm: wasm,
+        wasm,
       });
 
       const result = await this.invokePipe.run({
@@ -296,7 +297,7 @@ export class Contract {
       const deployOperation = Operation.createCustomContract({
         address: new Address(config.source),
         wasmHash: Buffer.from(wasmHash, "hex"),
-        salt: contractSalt,
+        salt: toBuffer(contractSalt),
         constructorArgs: encodedArgs,
       } as OperationOptions.CreateCustomContract);
 

--- a/core/contract/index.unit.test.ts
+++ b/core/contract/index.unit.test.ts
@@ -1,8 +1,4 @@
-import {
-  assertEquals,
-  assertExists,
-  assertThrows,
-} from "@std/assert";
+import { assertEquals, assertExists, assertThrows } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 import { Buffer } from "buffer";
 import { Contract } from "@/contract/index.ts";
@@ -55,6 +51,41 @@ describe("Contract", () => {
 
       assertEquals(contract.getWasm(), mockWasm);
     });
+
+    it("accepts structural binary wasm inputs without requiring Colibri's Buffer type", () => {
+      const mockRpc = {} as unknown as Server;
+      const networkConfig = NetworkConfig.CustomNet({
+        type: NetworkType.TESTNET,
+        networkPassphrase: "Test Network",
+      });
+      const uint8Contract = new Contract({
+        networkConfig,
+        contractConfig: {
+          wasm: new Uint8Array([1, 2, 3]),
+        },
+        rpc: mockRpc,
+      });
+      const arrayBuffer = new Uint8Array([4, 5, 6]).buffer;
+      const arrayBufferContract = new Contract({
+        networkConfig,
+        contractConfig: {
+          wasm: arrayBuffer,
+        },
+        rpc: mockRpc,
+      });
+      const source = new Uint8Array([0, 7, 8, 9, 0]);
+      const dataViewContract = new Contract({
+        networkConfig,
+        contractConfig: {
+          wasm: new DataView(source.buffer, 1, 3),
+        },
+        rpc: mockRpc,
+      });
+
+      assertEquals([...uint8Contract.getWasm()], [1, 2, 3]);
+      assertEquals([...arrayBufferContract.getWasm()], [4, 5, 6]);
+      assertEquals([...dataViewContract.getWasm()], [7, 8, 9]);
+    });
   });
 
   describe("construction Errors", () => {
@@ -69,7 +100,7 @@ describe("Contract", () => {
             networkConfig: undefined as unknown as NetworkConfig,
             contractConfig,
           }),
-        E.MISSING_ARG
+        E.MISSING_ARG,
       );
 
       assertThrows(
@@ -78,7 +109,7 @@ describe("Contract", () => {
             networkConfig: {} as unknown as NetworkConfig,
             contractConfig,
           }),
-        E.MISSING_ARG
+        E.MISSING_ARG,
       );
 
       assertThrows(
@@ -90,7 +121,7 @@ describe("Contract", () => {
             } as unknown as NetworkConfig,
             contractConfig: undefined as unknown as ContractConfig,
           }),
-        E.MISSING_ARG
+        E.MISSING_ARG,
       );
     });
 
@@ -107,7 +138,7 @@ describe("Contract", () => {
               wasm: mockWasm,
             },
           }),
-        E.MISSING_RPC_URL
+        E.MISSING_RPC_URL,
       );
     });
 
@@ -122,7 +153,7 @@ describe("Contract", () => {
             }),
             contractConfig: {} as unknown as ContractConfig,
           }),
-        E.INVALID_CONTRACT_CONFIG
+        E.INVALID_CONTRACT_CONFIG,
       );
     });
 
@@ -153,22 +184,22 @@ describe("Contract", () => {
 
       assertThrows(
         () => contractWithWasm.getWasmHash(),
-        E.MISSING_REQUIRED_PROPERTY
+        E.MISSING_REQUIRED_PROPERTY,
       );
 
       assertThrows(
         () => contractWithWasm.getSpec(),
-        E.MISSING_REQUIRED_PROPERTY
+        E.MISSING_REQUIRED_PROPERTY,
       );
 
       assertThrows(
         () => contractWithWasm.getContractId(),
-        E.MISSING_REQUIRED_PROPERTY
+        E.MISSING_REQUIRED_PROPERTY,
       );
 
       assertThrows(
         () => contractWithWasmHash.getWasm(),
-        E.MISSING_REQUIRED_PROPERTY
+        E.MISSING_REQUIRED_PROPERTY,
       );
     });
   });
@@ -250,8 +281,7 @@ describe("Contract", () => {
 
       const expectedOperation = Operation.invokeContractFunction({
         function: "hello",
-        contract:
-          "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        contract: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
         args: [],
       });
       assertEquals(

--- a/core/contract/types.ts
+++ b/core/contract/types.ts
@@ -1,5 +1,5 @@
-import type { Buffer } from "buffer";
 import type { NetworkConfig } from "@/network/index.ts";
+import type { BinaryData } from "@/common/types/index.ts";
 import type { Spec } from "stellar-sdk/contract";
 import type { Server } from "stellar-sdk/rpc";
 
@@ -14,13 +14,13 @@ export type ContractConstructorArgs = {
 export type ContractConfig = {
   spec?: Spec;
   contractId?: string;
-  wasm?: Buffer;
+  wasm?: BinaryData;
   wasmHash?: string;
 } & (ContractConfigWasm | ContractConfigWasmHash | ContractConfigId);
 
 /** @internal */
 export type ContractConfigWasm = {
-  wasm: Buffer;
+  wasm: BinaryData;
 };
 
 /** @internal */

--- a/core/deno.json
+++ b/core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@colibri/core",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "license": "MIT",
   "exports": {
     ".": "./mod.ts"

--- a/core/ledger-entries/keys.ts
+++ b/core/ledger-entries/keys.ts
@@ -6,7 +6,8 @@ import {
   xdr,
 } from "stellar-sdk";
 import { Buffer } from "buffer";
-import type { LedgerKeyLike } from "@/common/types/index.ts";
+import type { BinaryData, LedgerKeyLike } from "@/common/types/index.ts";
+import { toBuffer } from "@/common/helpers/internal-buffer.ts";
 import { StrKey } from "@/strkeys/index.ts";
 import * as E from "@/ledger-entries/error.ts";
 import { decodeByteFormBase64, toRawXdrBuffer } from "@/ledger-entries/xdr.ts";
@@ -166,7 +167,7 @@ function requireLiquidityPoolId(liquidityPoolId: string): void {
   }
 }
 
-function normalizeHashBytes(hashValue: string | Uint8Array): Buffer {
+function normalizeHashBytes(hashValue: string | BinaryData): Buffer {
   if (typeof hashValue === "string") {
     if (!HEX_32_BYTE_REGEX.test(hashValue)) {
       throw new E.INVALID_HEX_HASH(hashValue);
@@ -174,11 +175,12 @@ function normalizeHashBytes(hashValue: string | Uint8Array): Buffer {
     return Buffer.from(hashValue, "hex");
   }
 
-  if (hashValue.length !== 32) {
-    throw new E.INVALID_HEX_HASH(Buffer.from(hashValue).toString("hex"));
+  const hashBytes = toBuffer(hashValue);
+  if (hashBytes.length !== 32) {
+    throw new E.INVALID_HEX_HASH(hashBytes.toString("hex"));
   }
 
-  return Buffer.from(hashValue);
+  return hashBytes;
 }
 
 function normalizeContractDataDurability(
@@ -229,11 +231,12 @@ function normalizeLedgerKeyHash(
     }
   }
 
-  if (args.keyHash.length !== 32) {
+  const keyHash = toBuffer(args.keyHash);
+  if (keyHash.length !== 32) {
     throw new E.INVALID_LEDGER_KEY_HASH();
   }
 
-  return Buffer.from(args.keyHash);
+  return keyHash;
 }
 
 /**
@@ -311,9 +314,7 @@ export function buildDataLedgerKey({
     xdr.LedgerKey.data(
       new xdr.LedgerKeyData({
         accountId: Keypair.fromPublicKey(accountId).xdrAccountId(),
-        dataName: typeof dataName === "string"
-          ? dataName
-          : Buffer.from(dataName),
+        dataName: typeof dataName === "string" ? dataName : toBuffer(dataName),
       }),
     ),
   );

--- a/core/ledger-entries/keys.unit.test.ts
+++ b/core/ledger-entries/keys.unit.test.ts
@@ -75,11 +75,15 @@ describe("LedgerEntries key builders", () => {
       accountId: ACCOUNT_ID,
       dataName: new Uint8Array([1, 2, 3]),
     });
+    const dataViewKey = buildDataLedgerKey({
+      accountId: ACCOUNT_ID,
+      dataName: new DataView(new Uint8Array([0, 4, 5, 6, 0]).buffer, 1, 3),
+    });
     const codeKey = buildContractCodeLedgerKey({
-      hash: new Uint8Array(32).fill(5),
+      hash: new DataView(new Uint8Array(34).fill(5).buffer, 1, 32),
     });
     const ttlKey = buildTtlLedgerKey({
-      keyHash: new Uint8Array(32).fill(6),
+      keyHash: new DataView(new Uint8Array(34).fill(6).buffer, 1, 32),
     });
 
     assertEquals(
@@ -102,6 +106,12 @@ describe("LedgerEntries key builders", () => {
     assertEquals(
       Buffer.from((dataKey as unknown as xdr.LedgerKey).data().dataName()),
       Buffer.from([1, 2, 3]),
+    );
+    assertEquals(
+      Buffer.from(
+        (dataViewKey as unknown as xdr.LedgerKey).data().dataName(),
+      ),
+      Buffer.from([4, 5, 6]),
     );
     assertEquals(
       (codeKey as unknown as xdr.LedgerKey).contractCode().hash().length,

--- a/core/signer/local/index.ts
+++ b/core/signer/local/index.ts
@@ -1,13 +1,8 @@
-import type { Buffer } from "buffer";
-import {
-  authorizeEntry,
-  Keypair,
-  type xdr,
-} from "stellar-sdk";
+import { authorizeEntry, Keypair, type xdr } from "stellar-sdk";
 import type {
   BinaryData,
-  SorobanAuthorizationEntryLike,
   SignableTransaction,
+  SorobanAuthorizationEntryLike,
   TransactionXDRBase64,
 } from "@/common/types/index.ts";
 import type {
@@ -19,6 +14,7 @@ import type { LocalSigner as LocalSignerType } from "@/signer/local/types.ts";
 import * as E from "@/signer/local/error.ts";
 import { assert } from "@/common/assert/assert.ts";
 import { isDefined } from "@/common/type-guards/is-defined.ts";
+import { toBuffer } from "@/common/helpers/internal-buffer.ts";
 
 /**
  * LocalSigner
@@ -64,7 +60,7 @@ export class LocalSigner implements LocalSignerType {
    * @returns Signed transaction XDR as base64 text.
    */
   signTransaction: (
-    tx: SignableTransaction
+    tx: SignableTransaction,
   ) => TransactionXDRBase64;
 
   /**
@@ -78,7 +74,7 @@ export class LocalSigner implements LocalSignerType {
   signSorobanAuthEntry: (
     entry: SorobanAuthorizationEntryLike,
     validUntil: number,
-    passphrase: string
+    passphrase: string,
   ) => Promise<SorobanAuthorizationEntryLike>;
 
   /**
@@ -111,12 +107,12 @@ export class LocalSigner implements LocalSignerType {
     // Public methods close over `kp` to access secret material as needed.
     this.secretKey = hideSecret
       ? () => {
-          throw new E.SECRET_NOT_ACCESSIBLE();
-        }
+        throw new E.SECRET_NOT_ACCESSIBLE();
+      }
       : () => {
-          assert(isDefined(kp), new E.SIGNER_DESTROYED());
-          return kp.secret() as Ed25519SecretKey;
-        };
+        assert(isDefined(kp), new E.SIGNER_DESTROYED());
+        return kp.secret() as Ed25519SecretKey;
+      };
 
     const pub = kp.publicKey();
 
@@ -125,7 +121,7 @@ export class LocalSigner implements LocalSignerType {
 
     this.sign = (data: BinaryData): BinaryData => {
       assert(isDefined(kp), new E.SIGNER_DESTROYED());
-      return kp.sign(data as Buffer);
+      return kp.sign(toBuffer(data));
     };
 
     this.verifySignature = (
@@ -133,11 +129,11 @@ export class LocalSigner implements LocalSignerType {
       signature: BinaryData,
     ): boolean => {
       const keypair = Keypair.fromPublicKey(this.publicKey());
-      return keypair.verify(data as Buffer, signature as Buffer);
+      return keypair.verify(toBuffer(data), toBuffer(signature));
     };
 
     this.signTransaction = (
-      tx: SignableTransaction
+      tx: SignableTransaction,
     ): TransactionXDRBase64 => {
       assert(isDefined(kp), new E.SIGNER_DESTROYED());
       tx.sign(kp);
@@ -147,7 +143,7 @@ export class LocalSigner implements LocalSignerType {
     this.signSorobanAuthEntry = (
       entry: SorobanAuthorizationEntryLike,
       validUntil: number,
-      passphrase: string
+      passphrase: string,
     ): Promise<SorobanAuthorizationEntryLike> => {
       assert(isDefined(kp), new E.SIGNER_DESTROYED());
       return authorizeEntry(
@@ -184,7 +180,7 @@ export class LocalSigner implements LocalSignerType {
   static generateRandom(hideSecret = false): LocalSigner {
     return new LocalSigner(
       Keypair.random().secret() as Ed25519SecretKey,
-      hideSecret
+      hideSecret,
     );
   }
 

--- a/core/signer/local/index.unit.test.ts
+++ b/core/signer/local/index.unit.test.ts
@@ -8,16 +8,17 @@ import {
 import { Buffer } from "buffer";
 import { describe, it } from "@std/testing/bdd";
 import {
+  Account,
+  Asset,
+  Contract,
   Keypair,
   Networks,
   Operation,
   TransactionBuilder,
-  Asset,
   xdr,
-  Account,
-  Contract,
 } from "stellar-sdk";
 import { LocalSigner } from "@/signer/local/index.ts";
+import { normalizeBinaryData } from "@/common/helpers/binary.ts";
 import type {
   ContractId,
   Ed25519PublicKey,
@@ -53,10 +54,13 @@ describe("LocalSigner", () => {
         (k) => {
           const descriptor = Object.getOwnPropertyDescriptor(signer, k);
           return descriptor?.value === TEST_SECRET;
-        }
+        },
       );
 
-      assert(!hasSecretValue, "Secret value should not be stored directly on instance");
+      assert(
+        !hasSecretValue,
+        "Secret value should not be stored directly on instance",
+      );
     });
 
     it("creates a signer with hideSecret = false by default", () => {
@@ -69,7 +73,7 @@ describe("LocalSigner", () => {
       assertThrows(
         () => signer.secretKey(),
         E.SECRET_NOT_ACCESSIBLE,
-        "Secret key is not accessible"
+        "Secret key is not accessible",
       );
     });
   });
@@ -94,7 +98,7 @@ describe("LocalSigner", () => {
       assertThrows(
         () => signer.secretKey(),
         E.SECRET_NOT_ACCESSIBLE,
-        "Secret key is not accessible"
+        "Secret key is not accessible",
       );
     });
   });
@@ -110,7 +114,7 @@ describe("LocalSigner", () => {
       assertThrows(
         () => signer.secretKey(),
         E.SECRET_NOT_ACCESSIBLE,
-        "Secret key is not accessible"
+        "Secret key is not accessible",
       );
     });
 
@@ -230,7 +234,7 @@ describe("LocalSigner", () => {
       const signer = LocalSigner.fromSecret(TEST_SECRET);
       assertThrows(
         () => signer.removeTarget(TEST_PUBLIC),
-        E.CANNOT_REMOVE_MASTER_TARGET
+        E.CANNOT_REMOVE_MASTER_TARGET,
       );
     });
 
@@ -247,7 +251,7 @@ describe("LocalSigner", () => {
     it("signs a transaction and returns XDR", () => {
       const signer = LocalSigner.fromSecret(TEST_SECRET);
       const sourceKp = Keypair.fromSecret(TEST_SECRET);
-      
+
       const account = new Account(sourceKp.publicKey(), "0");
       const tx = new TransactionBuilder(account, {
         fee: "100",
@@ -258,7 +262,7 @@ describe("LocalSigner", () => {
             destination: Keypair.random().publicKey(),
             asset: Asset.native(),
             amount: "10",
-          })
+          }),
         )
         .setTimeout(30)
         .build();
@@ -268,7 +272,7 @@ describe("LocalSigner", () => {
       assertExists(xdr);
       assert(typeof xdr === "string");
       assert(xdr.length > 0);
-      
+
       // Verify signature was added
       assertEquals(tx.signatures.length, 1);
     });
@@ -287,14 +291,14 @@ describe("LocalSigner", () => {
             destination: Keypair.random().publicKey(),
             asset: Asset.native(),
             amount: "10",
-          })
+          }),
         )
         .setTimeout(30)
         .build();
 
       assertThrows(
         () => signer.signTransaction(tx),
-        E.SIGNER_DESTROYED
+        E.SIGNER_DESTROYED,
       );
     });
   });
@@ -319,7 +323,17 @@ describe("LocalSigner", () => {
 
       // Verify using stellar-sdk Keypair
       const keypair = Keypair.fromPublicKey(TEST_PUBLIC);
-      assert(keypair.verify(data, Buffer.from(signature)));
+      assert(keypair.verify(data, Buffer.from(normalizeBinaryData(signature))));
+    });
+
+    it("accepts structural binary data for signing and verification", () => {
+      const signer = LocalSigner.fromSecret(TEST_SECRET);
+      const bytes = new TextEncoder().encode("test message to sign");
+      const data = new DataView(bytes.buffer, bytes.byteOffset, bytes.length);
+
+      const signature = signer.sign(data);
+
+      assert(signer.verifySignature(data, signature));
     });
 
     it("produces different signatures for different data", () => {
@@ -331,8 +345,8 @@ describe("LocalSigner", () => {
       const sig2 = signer.sign(data2);
 
       assertNotEquals(
-        Buffer.from(sig1).toString("hex"),
-        Buffer.from(sig2).toString("hex")
+        Buffer.from(normalizeBinaryData(sig1)).toString("hex"),
+        Buffer.from(normalizeBinaryData(sig2)).toString("hex"),
       );
     });
 
@@ -344,7 +358,7 @@ describe("LocalSigner", () => {
 
       assertThrows(
         () => signer.sign(data),
-        E.SIGNER_DESTROYED
+        E.SIGNER_DESTROYED,
       );
     });
   });
@@ -408,31 +422,34 @@ describe("LocalSigner", () => {
   describe("signSorobanAuthEntry", () => {
     it("signs a Soroban auth entry", async () => {
       const signer = LocalSigner.fromSecret(TEST_SECRET);
-      
+
       // Create a minimal auth entry for testing
       const credentials = xdr.SorobanCredentials.sorobanCredentialsAddress(
         new xdr.SorobanAddressCredentials({
           address: xdr.ScAddress.scAddressTypeAccount(
             xdr.PublicKey.publicKeyTypeEd25519(
-              Keypair.fromPublicKey(TEST_PUBLIC).rawPublicKey()
-            )
+              Keypair.fromPublicKey(TEST_PUBLIC).rawPublicKey(),
+            ),
           ),
           nonce: xdr.Int64.fromString("0"),
           signatureExpirationLedger: 0,
           signature: xdr.ScVal.scvVec([]),
-        })
+        }),
       );
 
       const entry = new xdr.SorobanAuthorizationEntry({
         credentials,
         rootInvocation: new xdr.SorobanAuthorizedInvocation({
-          function: xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(
-            new xdr.InvokeContractArgs({
-              contractAddress:new Contract("CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM").address().toScAddress(),
-              functionName: "test",
-              args: [],
-            })
-          ),
+          function: xdr.SorobanAuthorizedFunction
+            .sorobanAuthorizedFunctionTypeContractFn(
+              new xdr.InvokeContractArgs({
+                contractAddress: new Contract(
+                  "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                ).address().toScAddress(),
+                functionName: "test",
+                args: [],
+              }),
+            ),
           subInvocations: [],
         }),
       });
@@ -441,7 +458,7 @@ describe("LocalSigner", () => {
       const signedEntry = await signer.signSorobanAuthEntry(
         entry,
         validUntil,
-        Networks.TESTNET
+        Networks.TESTNET,
       );
 
       assertExists(signedEntry);
@@ -455,13 +472,16 @@ describe("LocalSigner", () => {
       const entry = new xdr.SorobanAuthorizationEntry({
         credentials: xdr.SorobanCredentials.sorobanCredentialsSourceAccount(),
         rootInvocation: new xdr.SorobanAuthorizedInvocation({
-          function: xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(
-            new xdr.InvokeContractArgs({
-              contractAddress: new Contract("CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM").address().toScAddress(),
-              functionName: "test",
-              args: [],
-            })
-          ),
+          function: xdr.SorobanAuthorizedFunction
+            .sorobanAuthorizedFunctionTypeContractFn(
+              new xdr.InvokeContractArgs({
+                contractAddress: new Contract(
+                  "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                ).address().toScAddress(),
+                functionName: "test",
+                args: [],
+              }),
+            ),
           subInvocations: [],
         }),
       });
@@ -504,15 +524,15 @@ describe("LocalSigner", () => {
   });
 
   describe("Symbol.dispose", () => {
- it("calls destroy when using 'using' keyword", () => {
+    it("calls destroy when using 'using' keyword", () => {
       let signer: LocalSigner;
-      
+
       {
         using tempSigner = LocalSigner.fromSecret(TEST_SECRET);
         signer = tempSigner;
         assertEquals(signer.publicKey(), TEST_PUBLIC);
       }
-      
+
       // After scope, signer should be destroyed
       const account = new Account(TEST_PUBLIC, "0");
       const tx = new TransactionBuilder(account, {
@@ -524,7 +544,7 @@ describe("LocalSigner", () => {
 
       assertThrows(
         () => signer.signTransaction(tx),
-        E.SIGNER_DESTROYED
+        E.SIGNER_DESTROYED,
       );
     });
   });

--- a/plugins/channel-accounts/src/tools/helpers.unit.test.ts
+++ b/plugins/channel-accounts/src/tools/helpers.unit.test.ts
@@ -12,6 +12,7 @@ import {
   LocalSigner,
   NativeAccount,
   NetworkConfig,
+  normalizeBinaryData,
   type Signer,
   StrKey,
 } from "@colibri/core";
@@ -68,8 +69,7 @@ describe("ChannelAccounts helpers", () => {
             return [{
               weight: () => 1,
               key: () => ({
-                ed25519: () =>
-                  StrKey.decodeEd25519PublicKey(sponsor.address()),
+                ed25519: () => StrKey.decodeEd25519PublicKey(sponsor.address()),
               }),
             }];
           },
@@ -109,7 +109,7 @@ describe("ChannelAccounts helpers", () => {
       publicKey: () => sponsor.address(),
       sign: (data) => {
         calls.sign += 1;
-        return Buffer.from(data);
+        return Buffer.from(normalizeBinaryData(data));
       },
       signTransaction: () => {
         calls.signTransaction += 1;
@@ -174,9 +174,10 @@ describe("ChannelAccounts helpers", () => {
     const otherChannel = createChannelAccount();
 
     assertEquals(
-      chunkChannels([sponsor, channel, otherChannel] as ChannelAccount[], 2).map((
-        batch,
-      ) => batch.length),
+      chunkChannels([sponsor, channel, otherChannel] as ChannelAccount[], 2)
+        .map((
+          batch,
+        ) => batch.length),
       [2, 1],
     );
   });

--- a/sep10/deno.json
+++ b/sep10/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@colibri/sep10",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "exports": "./mod.ts",
   "license": "MIT",
   "publish": {
@@ -9,6 +9,6 @@
   },
   "imports": {
     "@/": "./src/",
-    "@colibri/core": "jsr:@colibri/core@^0.20.2"
+    "@colibri/core": "jsr:@colibri/core@^0.20.3"
   }
 }

--- a/sep10/src/challenge/challenge.ts
+++ b/sep10/src/challenge/challenge.ts
@@ -6,22 +6,22 @@
  */
 
 import {
+  Account,
+  Keypair,
+  Memo,
+  Operation,
   type Transaction,
   TransactionBuilder,
-  Keypair,
-  Operation,
-  Memo,
   xdr,
-  Account,
 } from "stellar-sdk";
 import { Buffer } from "buffer";
-import { isSigner } from "@colibri/core";
+import { isSigner, normalizeBinaryData } from "@colibri/core";
 import type { Signer } from "@colibri/core";
 import type {
   BuildChallengeOptions,
-  VerifyChallengeOptions,
   ChallengeOperation,
   ChallengeTimeBounds,
+  VerifyChallengeOptions,
 } from "@/types.ts";
 import * as E from "@/challenge/error.ts";
 import { isChallengeTransaction as _isChallengeTransaction } from "@/utils/is-challenge-transaction.ts";
@@ -86,7 +86,7 @@ export class SEP10Challenge {
       memo?: string;
       timeBounds: ChallengeTimeBounds;
       operations: ChallengeOperation[];
-    }
+    },
   ) {
     this._transaction = transaction;
     this._networkPassphrase = networkPassphrase;
@@ -132,7 +132,7 @@ export class SEP10Challenge {
     try {
       transaction = TransactionBuilder.fromXDR(
         xdr,
-        networkPassphrase
+        networkPassphrase,
       ) as Transaction;
     } catch (error) {
       throw new E.INVALID_XDR(error as Error, xdr);
@@ -159,7 +159,7 @@ export class SEP10Challenge {
    */
   static fromTransaction(
     transaction: Transaction,
-    networkPassphrase: string
+    networkPassphrase: string,
   ): SEP10Challenge {
     // Validate sequence number
     if (transaction.sequence !== "0") {
@@ -331,7 +331,7 @@ export class SEP10Challenge {
         source: clientAccount,
         name: `${homeDomain}${AUTH_KEY_SUFFIX}`,
         value: nonceBase64,
-      })
+      }),
     );
 
     // web_auth_domain operation
@@ -341,7 +341,7 @@ export class SEP10Challenge {
           source: serverAccount,
           name: "web_auth_domain",
           value: webAuthDomain,
-        })
+        }),
       );
     }
 
@@ -352,7 +352,7 @@ export class SEP10Challenge {
           source: clientDomainAccount,
           name: "client_domain",
           value: clientDomain,
-        })
+        }),
       );
     }
 
@@ -471,7 +471,7 @@ export class SEP10Challenge {
     options: Pick<
       VerifyChallengeOptions,
       "allowExpired" | "now" | "timeTolerance" | "skipTimeValidation"
-    > = {}
+    > = {},
   ): void {
     const {
       allowExpired = false,
@@ -556,7 +556,7 @@ export class SEP10Challenge {
    */
   verifyWebAuthDomain(
     serverPublicKey: string,
-    expectedWebAuthDomain?: string
+    expectedWebAuthDomain?: string,
   ): void {
     // Verify value matches if expected is provided
     if (
@@ -572,7 +572,7 @@ export class SEP10Challenge {
     // Verify source account is server
     if (this._webAuthDomain) {
       const webAuthOp = this._operations.find(
-        (op) => op.key === "web_auth_domain"
+        (op) => op.key === "web_auth_domain",
       );
       if (webAuthOp && webAuthOp.sourceAccount !== serverPublicKey) {
         throw new E.INVALID_WEB_AUTH_DOMAIN({
@@ -616,7 +616,7 @@ export class SEP10Challenge {
         throw new E.INVALID_OPERATION_SOURCE(
           op.key,
           op.sourceAccount,
-          serverPublicKey
+          serverPublicKey,
         );
       }
     }
@@ -683,7 +683,7 @@ export class SEP10Challenge {
    */
   isValid(
     serverPublicKey: string,
-    options: VerifyChallengeOptions = {}
+    options: VerifyChallengeOptions = {},
   ): boolean {
     try {
       this.verify(serverPublicKey, options);
@@ -720,11 +720,13 @@ export class SEP10Challenge {
   sign(signer: Keypair | Signer): this {
     if (isSigner(signer)) {
       const signature = Buffer.from(
-        signer.sign(Buffer.from(this._transaction.hash()))
+        normalizeBinaryData(
+          signer.sign(normalizeBinaryData(this._transaction.hash())),
+        ),
       );
       const hint = Keypair.fromPublicKey(signer.publicKey()).signatureHint();
       this._transaction.signatures.push(
-        new xdr.DecoratedSignature({ hint, signature })
+        new xdr.DecoratedSignature({ hint, signature }),
       );
     } else {
       this._transaction.sign(signer);


### PR DESCRIPTION
## Summary

- Broaden Colibri binary input handling so structural byte inputs work without requiring Colibri's bundled Buffer type.
- Normalize binary inputs at the contract, signer, ledger-key, wasm, and SEP-10 challenge boundaries.
- Add unit coverage for ArrayBuffer, typed-array byte offsets, DataView, and structural buffer-like inputs.

## Version bumps

- `@colibri/core`: `0.20.2` -> `0.20.3`
- `@colibri/sep10`: `0.5.7` -> `0.5.8`

## Verification

- `deno task check`
- `deno task check:jsr` passed with existing dependency type-resolution warnings from Stellar SDK / Dockerode declarations.
- `deno task test:unit` passed: `146 passed (2171 steps), 0 failed`.

Integration tests were not run per request.