### PR TITLE
Add SAC trust invocation

### DIFF
--- a/core/asset/sac/index.integration.test.ts
+++ b/core/asset/sac/index.integration.test.ts
@@ -69,6 +69,7 @@ describe("[Testnet] Stellar Asset Contract", disableSanitizeConfig, () => {
   const issuer = NativeAccount.fromMasterSigner(LocalSigner.generateRandom());
   const userA = NativeAccount.fromMasterSigner(LocalSigner.generateRandom());
   const userB = NativeAccount.fromMasterSigner(LocalSigner.generateRandom());
+  const userC = NativeAccount.fromMasterSigner(LocalSigner.generateRandom());
   const code = "COLIBRI";
 
   const asset = new Asset(code, issuer.address());
@@ -97,6 +98,10 @@ describe("[Testnet] Stellar Asset Contract", disableSanitizeConfig, () => {
       allowHttp: networkConfig.allowHttp,
     });
     await initializeWithFriendbot(networkConfig.friendbotUrl, userB.address(), {
+      rpcUrl: networkConfig.rpcUrl,
+      allowHttp: networkConfig.allowHttp,
+    });
+    await initializeWithFriendbot(networkConfig.friendbotUrl, userC.address(), {
       rpcUrl: networkConfig.rpcUrl,
       allowHttp: networkConfig.allowHttp,
     });
@@ -167,6 +172,25 @@ describe("[Testnet] Stellar Asset Contract", disableSanitizeConfig, () => {
         config: txConfig,
       });
       assertEquals(deployedSAC.contractId, contractId);
+    });
+
+    it("creates a classic account trustline through the CAP-0073 trust function", async () => {
+      await colibriSAC.trust({
+        address: userC.address(),
+        config: {
+          ...txConfig,
+          signers: [issuer.signer(), userC.signer()],
+        },
+      });
+      await wait();
+
+      const balance = await colibriSAC.balance({ id: userC.address() });
+      const isAuthorized = await colibriSAC.authorized({
+        id: userC.address(),
+      });
+
+      assertEquals(balance, 0n);
+      assertEquals(isAuthorized, true);
     });
 
     it("Reads from descriptive contract functions", async () => {

--- a/core/asset/sac/index.ts
+++ b/core/asset/sac/index.ts
@@ -99,7 +99,8 @@ const resolveAssetIdentity = (
  *
  * This class provides a high-level interface for interacting with Stellar Asset Contracts,
  * which are Soroban smart contracts that enable classic Stellar assets to be used within
- * the Soroban ecosystem. SACs implement the SEP-41 token interface and are defined in CAP-0046-06.
+ * the Soroban ecosystem. SACs implement the SEP-41 token interface and are
+ * defined in CAP-0046-06, with trustline creation support added by CAP-0073.
  *
  * SACs bridge classic Stellar assets with Soroban smart contracts while maintaining
  * compatibility with the existing Stellar asset system. A `StellarAssetContract`
@@ -107,6 +108,7 @@ const resolveAssetIdentity = (
  * and only needed when creating or deploying a SAC from a classic asset.
  *
  * @see {@link https://github.com/stellar/stellar-protocol/blob/master/core/cap-0046-06.md | CAP-0046-06}
+ * @see {@link https://github.com/stellar/stellar-protocol/blob/master/core/cap-0073.md | CAP-0073}
  * @see {@link https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0041.md | SEP-41}
  *
  * @example
@@ -710,6 +712,57 @@ export class StellarAssetContract {
       ...result,
       returnValue: undefined,
     } as ContractOutput[Method.Approve];
+  }
+
+  /**
+   * Creates an unlimited trustline for this asset on a Stellar account address.
+   *
+   * Use this before sending this asset to a classic Stellar account that does
+   * not already trust it. Existing trustlines are left unchanged, and contract
+   * addresses are ignored. If a new trustline is created, the account address
+   * must authorize the invocation.
+   *
+   * @param args - The trustline creation parameters
+   * @param args.address - The account address that should trust this asset
+   * @param args.config - Transaction configuration (fee, timeout, source, signers)
+   * @param args.auth - Optional pre-signed authorization entries
+   * @returns The invoke result with transaction details
+   *
+   * @see {@link https://github.com/stellar/stellar-protocol/blob/master/core/cap-0073.md | CAP-0073}
+   *
+   * @example
+   * ```typescript
+   * await sac.trust({
+   *   address: holderAddress,
+   *   config: {
+   *     fee: "10000000",
+   *     timeout: 30,
+   *     source: holderAddress,
+   *     signers: [holderSigner],
+   *   },
+   * });
+   * ```
+   */
+  public async trust({
+    address,
+    config,
+    auth,
+  }: ContractInput[Method.Trust] & BaseInvocation): Promise<
+    ContractOutput[Method.Trust]
+  > {
+    const result = await this.contract.invokeRaw({
+      operationArgs: {
+        function: Method.Trust,
+        args: [nativeToScVal(address, { type: "address" })],
+        auth,
+      },
+      config,
+    });
+
+    return {
+      ...result,
+      returnValue: undefined,
+    } as ContractOutput[Method.Trust];
   }
 
   /**

--- a/core/asset/sac/index.unit.test.ts
+++ b/core/asset/sac/index.unit.test.ts
@@ -305,6 +305,86 @@ describe("StellarAssetContract memoized descriptive reads", () => {
   });
 });
 
+describe("StellarAssetContract token invocations", () => {
+  const networkConfig = NetworkConfig.TestNet();
+  const issuer = LocalSigner.generateRandom();
+  const contractId = new Asset("TEST", issuer.publicKey()).contractId(
+    networkConfig.networkPassphrase,
+  ) as ContractId;
+
+  const txConfig: TransactionConfig = {
+    fee: "10000000",
+    timeout: 30,
+    source: issuer.publicKey(),
+    signers: [issuer],
+  };
+
+  let restoreInvokeRaw: (() => void) | undefined;
+
+  afterEach(() => {
+    restoreInvokeRaw?.();
+    restoreInvokeRaw = undefined;
+  });
+
+  const mockInvokeRaw = (
+    sac: StellarAssetContract,
+    implementation: (args: any) => Promise<unknown>,
+  ) => {
+    const originalInvokeRaw = sac.contract.invokeRaw.bind(sac.contract);
+
+    Object.defineProperty(sac.contract, "invokeRaw", {
+      value: implementation,
+      configurable: true,
+      writable: true,
+    });
+
+    restoreInvokeRaw = () => {
+      Object.defineProperty(sac.contract, "invokeRaw", {
+        value: originalInvokeRaw,
+        configurable: true,
+        writable: true,
+      });
+    };
+  };
+
+  it("invokes trust with the CAP-0073 address argument", async () => {
+    const sac = StellarAssetContract.fromContractId({
+      contractId,
+      networkConfig,
+    });
+    const address = LocalSigner.generateRandom().publicKey();
+    const auth = [] as any;
+    let receivedArgs: any;
+
+    mockInvokeRaw(sac, (args) => {
+      receivedArgs = args;
+      return Promise.resolve({
+        hash: "hash",
+        ledger: 1,
+        createdAt: 2,
+        response: {} as any,
+        returnValue: nativeToScVal(true, { type: "bool" }),
+      });
+    });
+
+    const result = await sac.trust({
+      address,
+      config: txConfig,
+      auth,
+    });
+
+    assertEquals(receivedArgs.operationArgs.function, Method.Trust);
+    assertEquals(receivedArgs.operationArgs.args.length, 1);
+    assertEquals(
+      receivedArgs.operationArgs.args[0].toXDR("base64"),
+      nativeToScVal(address, { type: "address" }).toXDR("base64"),
+    );
+    assertStrictEquals(receivedArgs.operationArgs.auth, auth);
+    assertStrictEquals(receivedArgs.config, txConfig);
+    assertEquals(result.returnValue, undefined);
+  });
+});
+
 describe("StellarAssetContract deployment error handling", () => {
   const networkConfig = NetworkConfig.TestNet();
   const issuer = LocalSigner.generateRandom();

--- a/core/asset/sac/types.ts
+++ b/core/asset/sac/types.ts
@@ -98,8 +98,9 @@ type InvokeOutput<V> = Omit<InvokeContractOutput, "returnValue"> & {
 /**
  * SAC (Stellar Asset Contract) Methods
  *
- * Based on CAP-0046-06:
+ * Based on CAP-0046-06 and CAP-0073:
  * https://github.com/stellar/stellar-protocol/blob/master/core/cap-0046-06.md
+ * https://github.com/stellar/stellar-protocol/blob/master/core/cap-0073.md
  */
 export enum Method {
   // Descriptive Interface
@@ -112,6 +113,7 @@ export enum Method {
   Approve = "approve",
   Balance = "balance",
   Authorized = "authorized",
+  Trust = "trust",
   Transfer = "transfer",
   TransferFrom = "transfer_from",
   Burn = "burn",
@@ -146,6 +148,9 @@ export type ContractInput = {
   };
   [Method.Authorized]: {
     id: Address;
+  };
+  [Method.Trust]: {
+    address: Address;
   };
   [Method.Transfer]: {
     from: Address;
@@ -204,6 +209,7 @@ export type ContractOutput = {
 
   // Token Interface (invoke)
   [Method.Approve]: InvokeOutput<undefined>;
+  [Method.Trust]: InvokeOutput<undefined>;
   [Method.Transfer]: InvokeOutput<undefined>;
   [Method.TransferFrom]: InvokeOutput<undefined>;
   [Method.Burn]: InvokeOutput<undefined>;

--- a/core/deno.json
+++ b/core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@colibri/core",
-  "version": "0.20.3",
+  "version": "0.21.0",
   "license": "MIT",
   "exports": {
     ".": "./mod.ts"

--- a/plugins/channel-accounts/deno.json
+++ b/plugins/channel-accounts/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@colibri/plugin-channel-accounts",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "exports": "./mod.ts",
   "license": "MIT",
   "publish": {
@@ -9,6 +9,6 @@
   },
   "imports": {
     "@/": "./src/",
-    "@colibri/core": "jsr:@colibri/core@^0.20.2"
+    "@colibri/core": "jsr:@colibri/core@^0.21.0"
   }
 }

--- a/plugins/fee-bump/deno.json
+++ b/plugins/fee-bump/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@colibri/plugin-fee-bump",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "exports": "./mod.ts",
   "license": "MIT",
   "publish": {
@@ -9,6 +9,6 @@
   },
   "imports": {
     "@/": "./src/",
-    "jsr:@colibri/core": "jsr:@colibri/core@^0.20.2"
+    "jsr:@colibri/core": "jsr:@colibri/core@^0.21.0"
   }
 }

--- a/rpc-streamer/deno.json
+++ b/rpc-streamer/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@colibri/rpc-streamer",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "exports": "./mod.ts",
   "license": "MIT",
   "publish": {
@@ -9,6 +9,6 @@
   },
   "imports": {
     "@/": "./src/",
-    "@colibri/core": "jsr:@colibri/core@^0.20.2"
+    "@colibri/core": "jsr:@colibri/core@^0.21.0"
   }
 }

--- a/sep10/deno.json
+++ b/sep10/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@colibri/sep10",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "exports": "./mod.ts",
   "license": "MIT",
   "publish": {
@@ -9,6 +9,6 @@
   },
   "imports": {
     "@/": "./src/",
-    "@colibri/core": "jsr:@colibri/core@^0.20.3"
+    "@colibri/core": "jsr:@colibri/core@^0.21.0"
   }
 }


### PR DESCRIPTION
## Summary

Adds CAP-0073 trustline support to the Stellar Asset Contract client by exposing `StellarAssetContract.trust(...)` and typing the new `trust` method in the SAC method/input/output maps.

## Version bumps

- `@colibri/core`: `0.20.3` -> `0.21.0` for the new public SAC trust API
- `@colibri/rpc-streamer`: `0.2.8` -> `0.2.9` for dependency alignment with `@colibri/core@^0.21.0`
- `@colibri/sep10`: `0.5.8` -> `0.5.9` for dependency alignment with `@colibri/core@^0.21.0`
- `@colibri/plugin-fee-bump`: `0.9.7` -> `0.9.8` for dependency alignment with `@colibri/core@^0.21.0`
- `@colibri/plugin-channel-accounts`: `0.2.4` -> `0.2.5` for dependency alignment with `@colibri/core@^0.21.0`

## Validation

- `deno test --allow-env --allow-net --allow-read --allow-run --allow-write core/asset/sac/index.unit.test.ts`
- `deno test -A --clean core/asset/sac/index.integration.test.ts`
- `deno task check`
- `deno task check:jsr`
- `git diff --check origin/dev...HEAD`

`deno task check:jsr` passes with existing external type-resolution warnings from Stellar SDK and dockerode typings.